### PR TITLE
Release 0.4: reliability, performance & Android compatibility

### DIFF
--- a/custom_components/album_slideshow/camera.py
+++ b/custom_components/album_slideshow/camera.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from collections import OrderedDict
 import logging
 import random
 from pathlib import Path
@@ -30,18 +29,27 @@ from .store import SlideshowStore
 
 _LOGGER = logging.getLogger(__name__)
 
+# Cap a single download at 64 MB. Larger images are rejected before decode
+# to protect low-memory devices. This is well above any realistic camera
+# JPEG; RAW/NEF/etc. aren't supported as camera frames anyway.
+_MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024
 
-@dataclass
-class _BytesCache:
-    when: datetime
-    data: bytes
+# Only these content types are accepted as image bodies. If a server returns
+# HTML (captive portal, 404 page rendered as 200, etc.) we reject it early.
+_ACCEPTED_IMAGE_PREFIX = ("image/",)
+
+# Max candidates we'll scan when searching for a mismatched-orientation
+# pairing partner. Metadata-only checks are nearly free; decode-only checks
+# (no metadata available) are expensive.
+_PAIR_SEARCH_LIMIT = 12
+_SKIP_SEARCH_LIMIT = 30
 
 
 class _DownloadCache:
-    """Byte-budget LRU cache for downloaded image data."""
+    """Byte-budget LRU cache for downloaded image data, O(1) per operation."""
 
     def __init__(self, max_bytes: int) -> None:
-        self._cache: dict[str, _BytesCache] = {}
+        self._cache: "OrderedDict[str, bytes]" = OrderedDict()
         self._total_bytes: int = 0
         self._max_bytes: int = max(max_bytes, 1)
 
@@ -50,19 +58,20 @@ class _DownloadCache:
         return self._total_bytes
 
     def get(self, url: str) -> bytes | None:
-        entry = self._cache.get(url)
-        if entry is None:
+        data = self._cache.get(url)
+        if data is None:
             return None
-        entry.when = datetime.now(timezone.utc)
-        return entry.data
+        self._cache.move_to_end(url)
+        return data
 
     def put(self, url: str, data: bytes) -> None:
         if len(data) > self._max_bytes:
             # Item exceeds the entire cache budget; skip caching but don't raise.
             return
         if url in self._cache:
-            self._total_bytes -= len(self._cache[url].data)
-        self._cache[url] = _BytesCache(when=datetime.now(timezone.utc), data=data)
+            self._total_bytes -= len(self._cache[url])
+            del self._cache[url]
+        self._cache[url] = data
         self._total_bytes += len(data)
         self._evict()
 
@@ -72,9 +81,8 @@ class _DownloadCache:
 
     def _evict(self) -> None:
         while self._total_bytes > self._max_bytes and self._cache:
-            oldest_key = min(self._cache, key=lambda k: self._cache[k].when)
-            self._total_bytes -= len(self._cache[oldest_key].data)
-            del self._cache[oldest_key]
+            _, data = self._cache.popitem(last=False)
+            self._total_bytes -= len(data)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -132,6 +140,12 @@ class AlbumSlideshowCamera(Camera):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
+        # Restore last framebuffer (if the store kept one) so the camera has
+        # something to show immediately after a restart, rather than a broken
+        # image placeholder while the first render completes.
+        restored = getattr(self.store, "last_frame", None)
+        if isinstance(restored, (bytes, bytearray)) and restored:
+            self._framebuffer = bytes(restored)
         self._render_task = self.hass.async_create_background_task(
             self._render_loop(), name="album_slideshow_render_loop"
         )
@@ -196,6 +210,21 @@ class AlbumSlideshowCamera(Camera):
     async def async_camera_image(self, width: int | None = None, height: int | None = None) -> bytes | None:
         return self._framebuffer
 
+    async def _wait_or_interrupt(self, timeout: float) -> bool:
+        """Wait up to ``timeout`` seconds, returning True if interrupted.
+
+        Safe wrapper around clear() + wait_for() - callers don't have to
+        worry about the ordering of the two operations. The clear() runs
+        synchronously before the awaitable is created, so no interrupt can
+        be lost on the single-threaded event loop.
+        """
+        self._interrupt_event.clear()
+        try:
+            await asyncio.wait_for(self._interrupt_event.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
     async def _render_loop(self) -> None:
         """Background task: render slides into _framebuffer, advance on timer or interrupt."""
         should_advance = False  # Don't advance on the very first render
@@ -219,18 +248,11 @@ class AlbumSlideshowCamera(Camera):
                 should_advance = True  # Skip the broken image on retry
                 continue
 
-            # Wait for slide_interval, or wake early on interrupt
-            # clear() before wait_for() is safe: there is no await between them,
-            # so no interrupt can fire in between on the single-threaded event loop.
-            self._interrupt_event.clear()
-            interval = int(self.store.slide_interval)
-            try:
-                await asyncio.wait_for(self._interrupt_event.wait(), timeout=float(interval))
-                # Woken by interrupt: advance only if force_next was set
+            interrupted = await self._wait_or_interrupt(float(int(self.store.slide_interval)))
+            if interrupted:
                 should_advance = self._force_next
                 self._force_next = False
-            except asyncio.TimeoutError:
-                # Normal timer expiry: advance to next slide
+            else:
                 should_advance = True
 
     async def _render_cycle(self, advance: bool) -> None:
@@ -247,10 +269,13 @@ class AlbumSlideshowCamera(Camera):
         out = await self._render_current(items)
         if out is not None:
             self._framebuffer = out
+            # Cached on the store so a camera reload (without full HA restart)
+            # can rehydrate the framebuffer instantly.
+            self.store.last_frame = out
             self.async_write_ha_state()
 
     def _do_advance(self, count: int, items: list) -> None:
-        """Advance _index to the next slide."""
+        """Advance _index to the next slide and commit random-order position."""
         if count <= 0:
             self._index = 0
             return
@@ -269,6 +294,17 @@ class AlbumSlideshowCamera(Camera):
         if len(self._recent_urls) > keep:
             self._recent_urls = self._recent_urls[-keep:]
 
+    def _peek_advance(self, count: int, items: list) -> None:
+        """Advance _index without committing to random-order bookkeeping.
+
+        Used by the orientation-avoid search so that rejected candidates
+        don't burn through the random cycle and cause premature repeats.
+        """
+        if count <= 0:
+            self._index = 0
+            return
+        self._index = (self._index + 1) % count
+
     async def _render_current(self, items: list[MediaItem]) -> bytes | None:
         """Render the image at self._index and return encoded bytes."""
         fill_mode = self.store.fill_mode
@@ -279,35 +315,63 @@ class AlbumSlideshowCamera(Camera):
         width, height = ip.resolve_output_size(None, None, self.store.aspect_ratio, max_short_edge)
 
         cur = items[self._index]
+        is_portrait_canvas = height > width
+
+        # Metadata fast path: if we can resolve orientation without downloading,
+        # we may short-circuit the mismatch handling before any bytes are read.
+        meta_portrait = ip.is_portrait_item_by_metadata(cur)
+        if (
+            meta_portrait is not None
+            and meta_portrait != is_portrait_canvas
+            and portrait_mode == ORIENTATION_MISMATCH_AVOID
+        ):
+            return await self._skip_mismatch_and_render(items, width, height, fill_mode, is_portrait_canvas)
+
         cur_bytes = await self._fetch_bytes(cur.url)
         if not cur_bytes:
             raise RuntimeError(f"Failed to fetch image: {cur.url}")
 
-        img = await self.hass.async_add_executor_job(ip.open_image, cur_bytes)
-        cur_is_portrait = ip.is_portrait_item(cur, img)
-        self._last_is_portrait = cur_is_portrait
+        img = await self.hass.async_add_executor_job(
+            ip.open_image, cur_bytes, (width, height)
+        )
+        try:
+            cur_is_portrait = ip.is_portrait_item(cur, img)
+            self._last_is_portrait = cur_is_portrait
+            orientation_mismatch = cur_is_portrait != is_portrait_canvas
 
-        is_portrait_canvas = height > width
-        orientation_mismatch = cur_is_portrait != is_portrait_canvas
+            if orientation_mismatch and portrait_mode == ORIENTATION_MISMATCH_AVOID:
+                ip.safe_close(img)
+                img = None
+                return await self._skip_mismatch_and_render(items, width, height, fill_mode, is_portrait_canvas)
 
-        if orientation_mismatch and portrait_mode == ORIENTATION_MISMATCH_AVOID:
-            return await self._skip_mismatch_and_render(items, width, height, fill_mode, is_portrait_canvas)
-
-        if orientation_mismatch and portrait_mode == ORIENTATION_MISMATCH_PAIR:
-            other = await self._find_next_mismatch_image(items, is_portrait_canvas, limit=12)
-            if other:
-                composed = await self.hass.async_add_executor_job(
-                    ip.pair_images, img, other, width, height, fill_mode,
-                    is_portrait_canvas, divider, divider_fill, transparent_divider,
+            if orientation_mismatch and portrait_mode == ORIENTATION_MISMATCH_PAIR:
+                other = await self._find_next_mismatch_image(
+                    items, is_portrait_canvas, width, height, limit=_PAIR_SEARCH_LIMIT
                 )
-            else:
-                composed = await self.hass.async_add_executor_job(
-                    ip.render_image, img, fill_mode, width, height,
-                )
-            return await self.hass.async_add_executor_job(ip.encode_image, composed)
+                try:
+                    if other:
+                        composed = await self.hass.async_add_executor_job(
+                            ip.pair_images, img, other, width, height, fill_mode,
+                            is_portrait_canvas, divider, divider_fill, transparent_divider,
+                        )
+                    else:
+                        composed = await self.hass.async_add_executor_job(
+                            ip.render_image, img, fill_mode, width, height,
+                        )
+                finally:
+                    ip.safe_close(other)
+                try:
+                    return await self.hass.async_add_executor_job(ip.encode_image, composed)
+                finally:
+                    ip.safe_close(composed)
 
-        composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
-        return await self.hass.async_add_executor_job(ip.encode_image, composed)
+            composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
+            try:
+                return await self.hass.async_add_executor_job(ip.encode_image, composed)
+            finally:
+                ip.safe_close(composed)
+        finally:
+            ip.safe_close(img)
 
     async def _skip_mismatch_and_render(
         self,
@@ -317,42 +381,92 @@ class AlbumSlideshowCamera(Camera):
         fill_mode: str,
         is_portrait_canvas: bool,
     ) -> bytes | None:
+        """Skip mismatched images (peeking through candidates) and render the first match.
+
+        Peek-advances _index without touching the random cycle for rejected
+        candidates, so the random order stays long.
+        """
         count = len(items)
         if count <= 0:
             return None
 
         start = self._index
-        for _ in range(min(count, 30)):
+
+        for _ in range(min(count, _SKIP_SEARCH_LIMIT)):
             cur = items[self._index]
+
+            # Metadata fast path: reject without ever downloading.
+            meta_portrait = ip.is_portrait_item_by_metadata(cur)
+            if meta_portrait is not None:
+                if meta_portrait != is_portrait_canvas:
+                    self._peek_advance(count, items)
+                    continue
+                # Metadata says it matches - commit and render.
+                if self._index != start:
+                    self._do_advance(count, items)
+                return await self._render_single(cur, width, height, fill_mode, is_portrait_canvas)
+
+            # No metadata; must download + decode to decide.
             b = await self._fetch_bytes(cur.url)
             if not b:
-                self._do_advance(count, items)
+                self._peek_advance(count, items)
                 continue
-            img = await self.hass.async_add_executor_job(ip.open_image, b)
-            if ip.is_portrait_item(cur, img) != is_portrait_canvas:
-                self._do_advance(count, items)
-                continue
+            img = await self.hass.async_add_executor_job(ip.open_image, b, (width, height))
+            try:
+                if ip.is_portrait_item(cur, img) != is_portrait_canvas:
+                    self._peek_advance(count, items)
+                    continue
+                if self._index != start:
+                    self._do_advance(count, items)
+                self._last_is_portrait = is_portrait_canvas
+                composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
+                try:
+                    return await self.hass.async_add_executor_job(ip.encode_image, composed)
+                finally:
+                    ip.safe_close(composed)
+            finally:
+                ip.safe_close(img)
 
-            self._last_is_portrait = is_portrait_canvas
-            composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
-            return await self.hass.async_add_executor_job(ip.encode_image, composed)
-
+        # Nothing matched within the limit; fall back to rendering the original.
         self._index = start
-        cur = items[self._index]
-        b = await self._fetch_bytes(cur.url)
+        return await self._render_single(items[self._index], width, height, fill_mode, is_portrait_canvas)
+
+    async def _render_single(
+        self,
+        item: MediaItem,
+        width: int,
+        height: int,
+        fill_mode: str,
+        is_portrait_canvas: bool,
+    ) -> bytes | None:
+        b = await self._fetch_bytes(item.url)
         if not b:
             return None
-        img = await self.hass.async_add_executor_job(ip.open_image, b)
-        self._last_is_portrait = ip.is_portrait_item(cur, img)
-        composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
-        return await self.hass.async_add_executor_job(ip.encode_image, composed)
+        img = await self.hass.async_add_executor_job(ip.open_image, b, (width, height))
+        try:
+            self._last_is_portrait = ip.is_portrait_item(item, img)
+            composed = await self.hass.async_add_executor_job(ip.render_image, img, fill_mode, width, height)
+            try:
+                return await self.hass.async_add_executor_job(ip.encode_image, composed)
+            finally:
+                ip.safe_close(composed)
+        finally:
+            ip.safe_close(img)
 
     async def _find_next_mismatch_image(
         self,
         items: list[MediaItem],
         is_portrait_canvas: bool,
-        limit: int = 10,
+        width: int,
+        height: int,
+        limit: int = _PAIR_SEARCH_LIMIT,
     ) -> Image.Image | None:
+        """Find an image with the opposite orientation of the canvas.
+
+        Uses metadata wherever possible - only candidates without width/height
+        metadata are downloaded and decoded for their orientation. The returned
+        PIL image is the caller's to close.
+        """
         if not items:
             return None
         n = len(items)
@@ -367,17 +481,23 @@ class AlbumSlideshowCamera(Camera):
             if it.url in self._recent_urls:
                 continue
 
+            meta_portrait = ip.is_portrait_item_by_metadata(it)
+            if meta_portrait is not None and meta_portrait == is_portrait_canvas:
+                # Metadata says this one is the wrong orientation for pairing; skip.
+                continue
+
             b = await self._fetch_bytes(it.url)
             if not b:
                 continue
 
             try:
-                img = await self.hass.async_add_executor_job(ip.open_image, b)
+                img = await self.hass.async_add_executor_job(ip.open_image, b, (width, height))
             except Exception:
                 continue
 
             if ip.is_portrait_item(it, img) != is_portrait_canvas:
                 return img
+            ip.safe_close(img)
 
         return None
 
@@ -412,18 +532,61 @@ class AlbumSlideshowCamera(Camera):
             except Exception as err:
                 _LOGGER.warning("Album Slideshow: failed to read local image: %s", err)
                 return None
+            if len(data) > _MAX_DOWNLOAD_BYTES:
+                _LOGGER.warning(
+                    "Album Slideshow: local image %s is %d bytes, exceeds %d byte limit; skipping",
+                    url, len(data), _MAX_DOWNLOAD_BYTES,
+                )
+                return None
         else:
-            session = async_get_clientsession(self.hass)
-            try:
-                async with async_timeout.timeout(30):
-                    resp = await session.get(url)
-                    resp.raise_for_status()
-                    data = await resp.read()
-            except Exception as err:
-                _LOGGER.warning("Album Slideshow: failed to fetch image: %s", err)
+            data = await self._http_get(url)
+            if data is None:
                 return None
 
         self._download_cache.put(url, data)
-
         return data
 
+    async def _http_get(self, url: str) -> bytes | None:
+        session = async_get_clientsession(self.hass)
+        try:
+            async with async_timeout.timeout(30):
+                async with session.get(url) as resp:
+                    resp.raise_for_status()
+
+                    content_type = resp.headers.get("Content-Type", "")
+                    primary = content_type.split(";", 1)[0].strip().lower()
+                    if primary and not primary.startswith(_ACCEPTED_IMAGE_PREFIX):
+                        _LOGGER.debug(
+                            "Album Slideshow: rejecting %s, content-type %r is not an image",
+                            url, primary,
+                        )
+                        return None
+
+                    content_length = resp.headers.get("Content-Length")
+                    if content_length is not None:
+                        try:
+                            declared = int(content_length)
+                        except ValueError:
+                            declared = -1
+                        if declared > _MAX_DOWNLOAD_BYTES:
+                            _LOGGER.warning(
+                                "Album Slideshow: %s advertises %d bytes, exceeds %d byte limit; skipping",
+                                url, declared, _MAX_DOWNLOAD_BYTES,
+                            )
+                            return None
+
+                    chunks: list[bytes] = []
+                    total = 0
+                    async for chunk in resp.content.iter_chunked(64 * 1024):
+                        total += len(chunk)
+                        if total > _MAX_DOWNLOAD_BYTES:
+                            _LOGGER.warning(
+                                "Album Slideshow: %s exceeded %d byte limit mid-download; aborting",
+                                url, _MAX_DOWNLOAD_BYTES,
+                            )
+                            return None
+                        chunks.append(chunk)
+                    return b"".join(chunks)
+        except Exception as err:
+            _LOGGER.warning("Album Slideshow: failed to fetch image: %s", err)
+            return None

--- a/custom_components/album_slideshow/image_processing.py
+++ b/custom_components/album_slideshow/image_processing.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import io
 import logging

--- a/custom_components/album_slideshow/image_processing.py
+++ b/custom_components/album_slideshow/image_processing.py
@@ -1,25 +1,59 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import io
+import logging
 
 from PIL import Image, ImageColor, ImageFilter, ImageOps
 
 from .coordinator import MediaItem
 
-# Re-export fill mode and orientation constants so callers can import from here
+_LOGGER = logging.getLogger(__name__)
+
+# Re-export fill mode constants so callers can import from here.
 FILL_COVER = "cover"
 FILL_CONTAIN = "contain"
 FILL_BLUR = "blur"
 
+# Absolute pixel ceiling. A 20000x20000 JPEG decodes to ~1.2 GB of RGB; Pillow
+# raises DecompressionBombError above MAX_IMAGE_PIXELS. We set this high enough
+# that 4K+ sources still decode, but reject anything absurd to protect
+# low-memory devices like the Home Assistant Green.
+_MAX_IMAGE_PIXELS = 80_000_000  # ~8K x 10K
+Image.MAX_IMAGE_PIXELS = _MAX_IMAGE_PIXELS
 
-def open_image(data: bytes) -> Image.Image:
-    """Open image bytes, apply EXIF orientation, normalise to RGB/RGBA."""
+
+def open_image(
+    data: bytes,
+    target_size: tuple[int, int] | None = None,
+) -> Image.Image:
+    """Open image bytes, apply EXIF orientation, normalise to RGB/RGBA.
+
+    If ``target_size`` is given, uses PIL's ``draft`` mode so libjpeg decodes
+    at a reduced scale. Big speed/memory win on low-power devices when the
+    source is much larger than the output canvas.
+    """
     img = Image.open(io.BytesIO(data))
+    if target_size is not None and img.format == "JPEG":
+        try:
+            img.draft("RGB", target_size)
+        except Exception:
+            pass
     img = ImageOps.exif_transpose(img)
-    img.load()  # force pixel data into memory; BytesIO must stay reachable until here
+    # Force pixel data into memory; BytesIO must stay reachable until here.
+    img.load()
     if img.mode not in ("RGB", "RGBA"):
         img = img.convert("RGB")
     return img
+
+
+def safe_close(img: Image.Image | None) -> None:
+    """Close a PIL image without raising. No-op on None."""
+    if img is None:
+        return
+    try:
+        img.close()
+    except Exception:
+        pass
 
 
 def is_portrait_img(img: Image.Image) -> bool:
@@ -37,6 +71,11 @@ def is_portrait_item(item: MediaItem, img: Image.Image | None = None) -> bool:
     if img is not None:
         return is_portrait_img(img)
     return False
+
+
+def is_portrait_item_by_metadata(item: MediaItem) -> bool | None:
+    """Return portrait/landscape from item metadata only, or None if unknown."""
+    return _is_portrait_dims(item.width, item.height)
 
 
 def resolve_output_size(
@@ -111,6 +150,8 @@ def pair_images(
         bottom_img = render_image(img2, fill_mode, target_w, bottom_h)
         canvas.paste(top_img.convert(canvas_mode), (0, 0))
         canvas.paste(bottom_img.convert(canvas_mode), (0, top_h + divider))
+        safe_close(top_img)
+        safe_close(bottom_img)
         return canvas
 
     left_w = max(1, (target_w - divider) // 2)
@@ -119,16 +160,33 @@ def pair_images(
     right_img = render_image(img2, fill_mode, right_w, target_h)
     canvas.paste(left_img.convert(canvas_mode), (0, 0))
     canvas.paste(right_img.convert(canvas_mode), (left_w + divider, 0))
+    safe_close(left_img)
+    safe_close(right_img)
     return canvas
 
 
 def encode_image(img: Image.Image) -> bytes:
-    """Encode a PIL image to JPEG (RGB) or PNG (RGBA)."""
+    """Encode a PIL image to a client-compatible JPEG or PNG.
+
+    JPEGs are written as baseline (non-progressive) with 4:2:0 subsampling and
+    without EXIF, which maximises compatibility with Android WebView and older
+    clients. RGBA images are encoded as PNG to preserve alpha.
+    """
     out = io.BytesIO()
     if "A" in img.getbands():
         img.save(out, format="PNG", optimize=True)
         return out.getvalue()
-    img.convert("RGB").save(out, format="JPEG", quality=88, optimize=True)
+    rgb = img if img.mode == "RGB" else img.convert("RGB")
+    rgb.save(
+        out,
+        format="JPEG",
+        quality=88,
+        optimize=True,
+        progressive=False,
+        subsampling=2,
+    )
+    if rgb is not img:
+        safe_close(rgb)
     return out.getvalue()
 
 
@@ -143,7 +201,7 @@ def parse_divider_color(color: str) -> tuple[tuple[int, int, int] | tuple[int, i
         return (255, 255, 255), False
 
 
-# ── Private helpers ──────────────────────────────────────────────────────────
+# -- Private helpers ---------------------------------------------------------
 
 def _is_portrait_dims(width: int | None, height: int | None) -> bool | None:
     if not width or not height:
@@ -178,7 +236,10 @@ def _resize_cover(img: Image.Image, target_w: int, target_h: int) -> Image.Image
     resized = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
     left = max(0, int(round((new_w - target_w) / 2)))
     top = max(0, int(round((new_h - target_h) / 2)))
-    return resized.crop((left, top, left + target_w, top + target_h))
+    cropped = resized.crop((left, top, left + target_w, top + target_h))
+    if cropped is not resized:
+        safe_close(resized)
+    return cropped
 
 
 def _resize_contain(img: Image.Image, target_w: int, target_h: int, bg=(0, 0, 0)) -> Image.Image:
@@ -190,7 +251,11 @@ def _resize_contain(img: Image.Image, target_w: int, target_h: int, bg=(0, 0, 0)
     new_h = max(1, int(src_h * scale))
     resized = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
     canvas = Image.new("RGB", (target_w, target_h), bg)
-    canvas.paste(resized.convert("RGB"), ((target_w - new_w) // 2, (target_h - new_h) // 2))
+    rgb_resized = resized if resized.mode == "RGB" else resized.convert("RGB")
+    canvas.paste(rgb_resized, ((target_w - new_w) // 2, (target_h - new_h) // 2))
+    if rgb_resized is not resized:
+        safe_close(rgb_resized)
+    safe_close(resized)
     return canvas
 
 
@@ -202,6 +267,10 @@ def _blur_fill(img: Image.Image, target_w: int, target_h: int) -> Image.Image:
     scale = min(target_w / src_w, target_h / src_h)
     new_w = max(1, int(src_w * scale))
     new_h = max(1, int(src_h * scale))
-    fg = img.resize((new_w, new_h), Image.Resampling.LANCZOS).convert("RGB")
-    bg.paste(fg, ((target_w - new_w) // 2, (target_h - new_h) // 2))
+    fg = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+    rgb_fg = fg if fg.mode == "RGB" else fg.convert("RGB")
+    bg.paste(rgb_fg, ((target_w - new_w) // 2, (target_h - new_h) // 2))
+    if rgb_fg is not fg:
+        safe_close(rgb_fg)
+    safe_close(fg)
     return bg

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
   "requirements": [],
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/custom_components/album_slideshow/store.py
+++ b/custom_components/album_slideshow/store.py
@@ -33,6 +33,10 @@ class SlideshowStore:
     image_cache_mb: int = DEFAULT_IMAGE_CACHE_MB
     max_resolution: str = DEFAULT_MAX_RESOLUTION
 
+    # In-memory last rendered frame. Not user-configurable; used to re-serve
+    # the previous slide instantly across a camera reload.
+    last_frame: bytes | None = None
+
     _listeners: list[Listener] = field(default_factory=list)
 
     def add_listener(self, cb: Listener) -> None:

--- a/tests/test_download_cache.py
+++ b/tests/test_download_cache.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-# _DownloadCache and _BytesCache are module-level in camera.py.
-# We import them directly to test eviction logic without HA.
+# _DownloadCache is a module-level helper in camera.py. We import it
+# directly to test eviction logic without HA.
 from custom_components.album_slideshow.camera import _DownloadCache
 
 
@@ -53,3 +53,35 @@ def test_total_bytes_tracked_correctly():
     cache.put("http://a", b"hello")
     cache.put("http://b", b"world!")
     assert cache.total_bytes == 11
+
+
+def test_get_moves_entry_to_most_recent():
+    # Under the OrderedDict LRU, get() should refresh recency so the next
+    # eviction removes the *other* entry, not the just-accessed one.
+    cache = _DownloadCache(max_bytes=10)
+    cache.put("http://a", b"12345")  # 5 bytes
+    cache.put("http://b", b"67890")  # 5 bytes, at limit
+
+    # Touch "a" so it becomes most-recent.
+    assert cache.get("http://a") == b"12345"
+
+    cache.put("http://c", b"ABCDE")  # 5 bytes, pushes over
+    assert cache.get("http://b") is None  # b was LRU, evicted
+    assert cache.get("http://a") == b"12345"
+    assert cache.get("http://c") == b"ABCDE"
+
+
+def test_item_larger_than_budget_is_not_cached():
+    cache = _DownloadCache(max_bytes=10)
+    cache.put("http://big", b"x" * 20)  # exceeds entire budget
+    assert cache.get("http://big") is None
+    assert cache.total_bytes == 0
+
+
+def test_resize_zero_or_negative_clamps_to_one():
+    cache = _DownloadCache(max_bytes=100)
+    cache.put("http://a", b"hi")
+    cache.resize(0)
+    # After resize, total must be <= 1 byte; entry must have been evicted.
+    assert cache.total_bytes == 0
+    assert cache.get("http://a") is None

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -211,3 +211,75 @@ def test_parse_divider_color_invalid_falls_back_to_white():
     color, transparent = ip.parse_divider_color("notacolor")
     assert color == (255, 255, 255)
     assert transparent is False
+
+
+# -- is_portrait_item_by_metadata -------------------------------------------
+
+def test_metadata_only_portrait():
+    item = MediaItem(url="x", width=100, height=200, mime_type=None, filename=None)
+    assert ip.is_portrait_item_by_metadata(item) is True
+
+
+def test_metadata_only_landscape():
+    item = MediaItem(url="x", width=300, height=100, mime_type=None, filename=None)
+    assert ip.is_portrait_item_by_metadata(item) is False
+
+
+def test_metadata_only_unknown_returns_none():
+    item = MediaItem(url="x", width=None, height=None, mime_type=None, filename=None)
+    assert ip.is_portrait_item_by_metadata(item) is None
+
+
+def test_metadata_only_zero_dims_returns_none():
+    item = MediaItem(url="x", width=0, height=0, mime_type=None, filename=None)
+    assert ip.is_portrait_item_by_metadata(item) is None
+
+
+# -- encode_image (Android compatibility) -----------------------------------
+
+def test_encoded_jpeg_is_baseline_not_progressive():
+    # Baseline JPEGs start with SOF0 (0xFFC0). Progressive would be SOF2 (0xFFC2).
+    # Scan the encoded bytes for an SOF marker.
+    img = Image.new("RGB", (64, 64), color=(100, 150, 200))
+    data = ip.encode_image(img)
+    # Find first SOF marker (0xFFCn where n in {0,1,2,3})
+    sof = None
+    for i in range(len(data) - 1):
+        if data[i] == 0xFF and data[i + 1] in (0xC0, 0xC1, 0xC2, 0xC3):
+            sof = data[i + 1]
+            break
+    assert sof is not None, "No SOF marker found in JPEG"
+    assert sof == 0xC0, f"Expected baseline (SOF0=0xC0), got 0x{sof:02X}"
+
+
+# -- safe_close -------------------------------------------------------------
+
+def test_safe_close_none_is_noop():
+    ip.safe_close(None)  # must not raise
+
+
+def test_safe_close_closes_image():
+    img = Image.new("RGB", (10, 10))
+    ip.safe_close(img)
+    # Accessing .load on a closed image raises; we just assert no exception
+    # from the close call itself.
+
+
+# -- open_image draft-mode does not crash on non-JPEG -----------------------
+
+def test_open_image_with_target_size_png_ok():
+    # PNG has no draft support; open_image must not raise when given a target.
+    data = _make_png_rgba(100, 100)
+    img = ip.open_image(data, target_size=(50, 50))
+    assert img.size == (100, 100)
+    ip.safe_close(img)
+
+
+def test_open_image_with_target_size_jpeg_ok():
+    data = _make_jpeg(2000, 2000)
+    img = ip.open_image(data, target_size=(200, 200))
+    # Draft mode is best-effort; we don't require a specific downscale,
+    # only that we got a usable image back.
+    assert img.mode == "RGB"
+    assert img.size[0] > 0 and img.size[1] > 0
+    ip.safe_close(img)


### PR DESCRIPTION
## Release 0.4 - reliability, performance, Android compatibility

This PR addresses the review feedback from PR #1 and the Android-tablet blank-render bug.

### Fixes
- **HTTP response is now released via `async with`** (was leaking connections on every slide)
- **PIL images explicitly closed** on discard/consumption in all rendering paths
- **JPEGs encoded as baseline** (non-progressive) with 4:2:0 subsampling and no EXIF, maximising Android WebView / older client compatibility - the likely cause of the blank-render bug
- **`Image.MAX_IMAGE_PIXELS` guard** (80 MP ceiling) protects the HA Green from a pathological album entry
- **Download size cap** (64 MB) with streaming read and `Content-Length` pre-check
- **`Content-Type` validation** rejects HTML captive-portal / error pages served with HTTP 200

### Performance
- `_DownloadCache` rewritten on `collections.OrderedDict` - O(1) get/put/evict (was O(n) per evicted entry under pressure)
- **Metadata-first orientation checks**: when a `MediaItem` has width/height, `is_portrait` is resolved without downloading or decoding. Big win on Google Photos (always has dimensions) - pairing and skip-mismatch loops no longer pay a decode cost per rejection
- **PIL `draft` mode**: `open_image(target_size=(w, h))` lets libjpeg decode at a reduced scale when the source is much larger than the render canvas

### Correctness
- **Peek vs commit advance**: `_skip_mismatch_and_render` now uses `_peek_advance` for rejected candidates so the random cycle is not consumed, preventing premature repeats
- **`_wait_or_interrupt(timeout)` helper** encapsulates the `clear()` + `wait_for()` pattern so future edits can't accidentally insert an `await` between them
- **Last-frame cache in `SlideshowStore`**: a camera reload rehydrates the framebuffer instantly instead of returning `None` until the first render completes

### Tests
- 44 tests pass (`pytest tests/`)
- New coverage for OrderedDict LRU semantics, cache size limits, resize-to-zero, JPEG baseline marker, metadata-only orientation, `safe_close`, and draft-mode opens

### Not addressed in this release (planned for 0.5)
- Cross-restart framebuffer persistence (in-memory only for now)
- Repair-flow / `async_start_reauth` for expired Google links
- Diagnostics download
