### PR TITLE
Release 0.5: bypass Google Photos ~300-photo cap via HTML scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,11 @@ When transparency is used, the integration outputs PNG to preserve alpha.
 
 ### Google Photos
 
-- Shared albums typically return only about 300 photos  
-- This is an upstream API limitation  
-- Videos are skipped  
-- Internet connection required  
+- Public shared albums only (link sharing must be enabled)
+- Up to 20,000 photos per album
+- Videos are skipped
+- Internet connection required
+- Relies on Google's public web endpoints; if Google changes them, the integration falls back to a 300-photo limit until the scraper is updated
 
 ### General
 

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -354,8 +354,8 @@ class AlbumCoordinator(DataUpdateCoordinator):
         # Threshold: if scrape returns >= 250 items we trust it; otherwise we
         # also call publicalbum.org and use whichever returns more.
         if len(scraped_items) >= 250:
-            _LOGGER.debug(
-                "Google shared album: scrape returned %d items, skipping publicalbum.org",
+            _LOGGER.info(
+                "Album scraper: source=batchexecute items=%d",
                 len(scraped_items),
             )
             return {
@@ -368,7 +368,7 @@ class AlbumCoordinator(DataUpdateCoordinator):
         except UpdateFailed:
             if scraped_items:
                 _LOGGER.info(
-                    "Google shared album: publicalbum.org failed; using %d scraped items",
+                    "Album scraper: source=batchexecute items=%d (publicalbum.org failed)",
                     len(scraped_items),
                 )
                 return {
@@ -409,8 +409,8 @@ class AlbumCoordinator(DataUpdateCoordinator):
         # Pick the source with more items; prefer publicalbum.org on a tie
         # because its URLs come pre-decorated with size hints.
         if len(scraped_items) > len(api_items):
-            _LOGGER.debug(
-                "Google shared album: scrape (%d) > publicalbum.org (%d); using scrape",
+            _LOGGER.info(
+                "Album scraper: source=batchexecute items=%d (publicalbum.org=%d)",
                 len(scraped_items), len(api_items),
             )
             return {
@@ -435,9 +435,9 @@ class AlbumCoordinator(DataUpdateCoordinator):
                 )
             raise UpdateFailed("No photos returned from Google shared album")
 
-        _LOGGER.debug(
-            "Google shared album: scrape=%d, publicalbum.org=%d; using publicalbum.org",
-            len(scraped_items), len(api_items),
+        _LOGGER.info(
+            "Album scraper: source=publicalbum items=%d (batchexecute=%d)",
+            len(api_items), len(scraped_items),
         )
         return {
             "title": result.get("title") or self.entry.title,

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import json
 import logging
 from pathlib import Path
-import re
 from typing import Any
 
 import async_timeout
@@ -335,19 +334,19 @@ class AlbumCoordinator(DataUpdateCoordinator):
 
         session = async_get_clientsession(self.hass)
 
-        # Try direct HTML scrape first - bypasses publicalbum.org's ~300 cap.
+        # Try direct scrape first - paginates via Google's batchexecute RPC
+        # to bypass publicalbum.org's ~300 cap.
         scraped_items: list[MediaItem] = []
         scraped_title: str | None = None
         try:
             from . import google_scraper
 
-            html = await google_scraper.fetch_album_html(session, self.album_url)
-            if html:
-                scraped_items = google_scraper.parse_album_html(html)
-                scraped_title = _extract_html_title(html)
+            scraped_title, scraped_items = await google_scraper.fetch_album(
+                session, self.album_url
+            )
         except Exception as err:  # never let scrape failure break the integration
             _LOGGER.debug(
-                "Google shared album: HTML scrape raised %s; falling back to publicalbum.org",
+                "Google shared album: scrape raised %s; falling back to publicalbum.org",
                 err,
             )
 
@@ -444,18 +443,3 @@ class AlbumCoordinator(DataUpdateCoordinator):
             "title": result.get("title") or self.entry.title,
             "items": api_items,
         }
-
-
-_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-
-
-def _extract_html_title(html: str) -> str | None:
-    m = _TITLE_RE.search(html)
-    if not m:
-        return None
-    title = m.group(1).strip()
-    # Google's share pages title is typically '<album name> - Google Photos'.
-    suffix = " - Google Photos"
-    if title.endswith(suffix):
-        title = title[: -len(suffix)].strip()
-    return title or None

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import json
 import logging
 from pathlib import Path
+import re
 from typing import Any
 
 import async_timeout
@@ -334,14 +335,91 @@ class AlbumCoordinator(DataUpdateCoordinator):
 
         session = async_get_clientsession(self.hass)
 
-        data = await self._call_publicalbum(session, 500)
+        # Try direct HTML scrape first - bypasses publicalbum.org's ~300 cap.
+        scraped_items: list[MediaItem] = []
+        scraped_title: str | None = None
+        try:
+            from . import google_scraper
+
+            html = await google_scraper.fetch_album_html(session, self.album_url)
+            if html:
+                scraped_items = google_scraper.parse_album_html(html)
+                scraped_title = _extract_html_title(html)
+        except Exception as err:  # never let scrape failure break the integration
+            _LOGGER.debug(
+                "Google shared album: HTML scrape raised %s; falling back to publicalbum.org",
+                err,
+            )
+
+        # Run publicalbum.org in parallel-ish: only call it if scrape was thin.
+        # Threshold: if scrape returns >= 250 items we trust it; otherwise we
+        # also call publicalbum.org and use whichever returns more.
+        if len(scraped_items) >= 250:
+            _LOGGER.debug(
+                "Google shared album: scrape returned %d items, skipping publicalbum.org",
+                len(scraped_items),
+            )
+            return {
+                "title": scraped_title or self.entry.title,
+                "items": scraped_items,
+            }
+
+        try:
+            data = await self._call_publicalbum(session, 500)
+        except UpdateFailed:
+            if scraped_items:
+                _LOGGER.info(
+                    "Google shared album: publicalbum.org failed; using %d scraped items",
+                    len(scraped_items),
+                )
+                return {
+                    "title": scraped_title or self.entry.title,
+                    "items": scraped_items,
+                }
+            raise
 
         result = data.get("result") if isinstance(data, dict) else {}
         if not isinstance(result, dict):
             result = {}
 
         page_items = _find_largest_item_list(result) or _find_largest_item_list(data)
-        if not page_items:
+        api_items: list[MediaItem] = []
+        if page_items:
+            seen_urls: set[str] = set()
+            for raw in page_items:
+                if _looks_like_video(raw):
+                    continue
+
+                url = _pick_url(raw)
+                if not url:
+                    continue
+                if url in seen_urls:
+                    continue
+                seen_urls.add(url)
+
+                filename = raw.get("filename") or raw.get("name")
+                width = _pick_int(raw, "mediaMetadata", "width") or _pick_int(raw, "width")
+                height = _pick_int(raw, "mediaMetadata", "height") or _pick_int(raw, "height")
+                mime = raw.get("mimeType") if isinstance(raw.get("mimeType"), str) else None
+
+                api_items.append(MediaItem(
+                    url=url, width=width, height=height,
+                    mime_type=mime, filename=filename,
+                ))
+
+        # Pick the source with more items; prefer publicalbum.org on a tie
+        # because its URLs come pre-decorated with size hints.
+        if len(scraped_items) > len(api_items):
+            _LOGGER.debug(
+                "Google shared album: scrape (%d) > publicalbum.org (%d); using scrape",
+                len(scraped_items), len(api_items),
+            )
+            return {
+                "title": scraped_title or result.get("title") or self.entry.title,
+                "items": scraped_items,
+            }
+
+        if not api_items and not scraped_items:
             try:
                 raw_json = json.dumps(data, default=str)
                 _LOGGER.warning(
@@ -356,37 +434,28 @@ class AlbumCoordinator(DataUpdateCoordinator):
                     list(data.keys()) if isinstance(data, dict) else type(data).__name__,
                     list(result.keys()) if isinstance(result, dict) else type(result).__name__,
                 )
-            raise UpdateFailed("No photos returned from publicalbum.org API")
-
-        items: list[MediaItem] = []
-        seen_urls: set[str] = set()
-        for raw in page_items:
-            if _looks_like_video(raw):
-                continue
-
-            url = _pick_url(raw)
-            if not url:
-                continue
-            if url in seen_urls:
-                continue
-            seen_urls.add(url)
-
-            filename = raw.get("filename") or raw.get("name")
-            width = _pick_int(raw, "mediaMetadata", "width") or _pick_int(raw, "width")
-            height = _pick_int(raw, "mediaMetadata", "height") or _pick_int(raw, "height")
-            mime = raw.get("mimeType") if isinstance(raw.get("mimeType"), str) else None
-
-            items.append(MediaItem(
-                url=url, width=width, height=height,
-                mime_type=mime, filename=filename,
-            ))
+            raise UpdateFailed("No photos returned from Google shared album")
 
         _LOGGER.debug(
-            "Google shared album: %d raw items, %d photos returned",
-            len(page_items), len(items),
+            "Google shared album: scrape=%d, publicalbum.org=%d; using publicalbum.org",
+            len(scraped_items), len(api_items),
         )
-
         return {
             "title": result.get("title") or self.entry.title,
-            "items": items,
+            "items": api_items,
         }
+
+
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+def _extract_html_title(html: str) -> str | None:
+    m = _TITLE_RE.search(html)
+    if not m:
+        return None
+    title = m.group(1).strip()
+    # Google's share pages title is typically '<album name> - Google Photos'.
+    suffix = " - Google Photos"
+    if title.endswith(suffix):
+        title = title[: -len(suffix)].strip()
+    return title or None

--- a/custom_components/album_slideshow/google_scraper.py
+++ b/custom_components/album_slideshow/google_scraper.py
@@ -1,0 +1,300 @@
+"""Direct scraper for Google Photos shared album HTML pages.
+
+publicalbum.org's JSON-RPC wrapper caps results at ~250-500 items because the
+upstream Google embed-player endpoint refuses to return more. The shared album
+HTML page itself, however, contains the *full* photo list embedded in
+``AF_initDataCallback`` JavaScript blocks. This module fetches the HTML and
+walks the embedded data to extract every photo, with no pagination cap.
+
+Brittleness note: Google rearranges the AF block structure roughly every
+6-18 months. This parser is intentionally structural rather than positional -
+it walks the JSON tree looking for arrays of items shaped like photos
+(googleusercontent URL + width + height) rather than indexing into specific
+positions. That trades some risk of false positives for survivability across
+minor Google changes. Callers should keep ``publicalbum.org`` as a fallback.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from .coordinator import MediaItem
+
+_LOGGER = logging.getLogger(__name__)
+
+# AF_initDataCallback({key: 'ds:N', ..., data: <JSON>, sideChannel: {...}});
+# We want the `data:` value. The argument to AF_initDataCallback is a JS object
+# literal with unquoted keys, so we cannot JSON.parse the whole thing. Instead
+# we locate `data:` and bracket-balance from its first `[`.
+_AF_BLOCK_RE = re.compile(r"AF_initDataCallback\s*\(\s*\{", re.DOTALL)
+_DATA_KEY_RE = re.compile(r"[\s,{]data\s*:\s*\[", re.DOTALL)
+
+# A "photo URL" is a Google-served image URL. Live photos and shared albums
+# usually use lh3-lh6.googleusercontent.com, but we accept any
+# googleusercontent host plus the rarer photos.fife.usercontent.google.com.
+_PHOTO_HOST_RE = re.compile(
+    r"^https?://(?:[a-z0-9-]+\.)?(?:googleusercontent\.com|google\.com)/",
+    re.IGNORECASE,
+)
+
+# Common Google image URL size suffix: =w<W>-h<H>-...
+_SIZE_SUFFIX_RE = re.compile(r"=[wh]\d+(?:-[a-z0-9]+)*$", re.IGNORECASE)
+
+# Browser-ish user agent so Google's CDN serves us the full HTML page rather
+# than a 'please enable JavaScript' shim.
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+# Hard ceiling on items returned, mirroring the per-album cap Google enforces
+# (20,000) so a malicious or pathological page can't blow up the integration.
+_MAX_ITEMS = 20_000
+
+
+async def fetch_album_html(session, url: str, *, timeout: float = 30.0) -> str | None:
+    """Fetch the shared album page HTML. Returns None on failure."""
+    headers = {
+        "User-Agent": _BROWSER_USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    try:
+        async with session.get(url, headers=headers, timeout=timeout, allow_redirects=True) as resp:
+            resp.raise_for_status()
+            ct = resp.headers.get("Content-Type", "").lower()
+            if "html" not in ct and "text" not in ct:
+                _LOGGER.debug("Album scrape: unexpected content-type %r for %s", ct, url)
+                return None
+            return await resp.text()
+    except Exception as err:
+        _LOGGER.debug("Album scrape: failed to fetch %s: %s", url, err)
+        return None
+
+
+def parse_album_html(html: str) -> list[MediaItem]:
+    """Parse the HTML and return the extracted media items.
+
+    Returns an empty list if no recognisable photo data was found.
+    """
+    candidates: list[list[Any]] = []
+    for blob in _iter_data_blobs(html):
+        try:
+            tree = json.loads(blob)
+        except json.JSONDecodeError as err:
+            _LOGGER.debug("Album scrape: skipped malformed data blob (%s)", err)
+            continue
+        candidates.extend(_collect_photo_lists(tree))
+
+    if not candidates:
+        return []
+
+    # Pick the largest list - the album item list is normally an order of
+    # magnitude longer than any side data (album owner, etc.).
+    best = max(candidates, key=len)
+
+    items: list[MediaItem] = []
+    seen_urls: set[str] = set()
+    for raw in best:
+        media = _photo_to_media_item(raw)
+        if media is None:
+            continue
+        if media.url in seen_urls:
+            continue
+        seen_urls.add(media.url)
+        items.append(media)
+        if len(items) >= _MAX_ITEMS:
+            break
+
+    return items
+
+
+# -- Internals ---------------------------------------------------------------
+
+def _iter_data_blobs(html: str):
+    """Yield the JSON text of every AF_initDataCallback ``data:`` value."""
+    for m in _AF_BLOCK_RE.finditer(html):
+        # Find the matching closing ')' of the AF_initDataCallback call.
+        block_end = _balanced_close(html, m.end() - 1, "{", "}")
+        if block_end is None:
+            continue
+        block = html[m.end() - 1: block_end + 1]
+
+        data_match = _DATA_KEY_RE.search(block)
+        if data_match is None:
+            continue
+        # Position of the '[' that opens the data array.
+        open_pos = data_match.end() - 1
+        close_pos = _balanced_close(block, open_pos, "[", "]")
+        if close_pos is None:
+            continue
+        yield block[open_pos: close_pos + 1]
+
+
+def _balanced_close(s: str, open_idx: int, open_char: str, close_char: str) -> int | None:
+    """Return the index of the matching close for an opening bracket.
+
+    Tracks string literals so brackets inside JS strings don't unbalance us.
+    Handles both single-quoted (JS) and double-quoted (JSON) strings, and
+    backslash escapes inside them.
+    """
+    if open_idx >= len(s) or s[open_idx] != open_char:
+        return None
+    depth = 0
+    in_string: str | None = None
+    i = open_idx
+    n = len(s)
+    while i < n:
+        c = s[i]
+        if in_string is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_string:
+                in_string = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            in_string = c
+            i += 1
+            continue
+        if c == open_char:
+            depth += 1
+        elif c == close_char:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None
+
+
+def _collect_photo_lists(node: Any, _out: list[list[Any]] | None = None) -> list[list[Any]]:
+    """Walk a parsed JSON tree and collect every list whose items look like photos."""
+    out = _out if _out is not None else []
+    if isinstance(node, list):
+        if _list_looks_like_photos(node):
+            out.append(node)
+        for child in node:
+            _collect_photo_lists(child, out)
+    elif isinstance(node, dict):
+        for child in node.values():
+            _collect_photo_lists(child, out)
+    return out
+
+
+def _list_looks_like_photos(lst: list[Any]) -> bool:
+    """Heuristic: a non-empty list whose every (sampled) entry is photo-shaped.
+
+    We sample the head of the list to bound work on huge album lists, and we
+    require *every* sampled entry to parse as a MediaItem. The 'pick largest'
+    logic in parse_album_html then disambiguates between the real photo list
+    and shorter incidental ones (actors, members) without us having to
+    fingerprint the wrapping shape.
+    """
+    if not lst:
+        return False
+    sample = lst[:20]
+    for item in sample:
+        if _photo_to_media_item(item) is None:
+            return False
+    return True
+
+
+def _photo_to_media_item(raw: Any) -> MediaItem | None:
+    """Extract a MediaItem from a single photo entry, or return None."""
+    if not isinstance(raw, list):
+        return None
+
+    url = _find_photo_url(raw)
+    if not url:
+        return None
+
+    width, height = _find_dimensions(raw)
+    return MediaItem(
+        url=_normalise_size(url, width, height),
+        width=width,
+        height=height,
+        mime_type=None,
+        filename=None,
+    )
+
+
+def _find_photo_url(node: Any) -> str | None:
+    """First googleusercontent.com URL found anywhere in ``node``."""
+    if isinstance(node, str):
+        if _PHOTO_HOST_RE.match(node):
+            return node
+        return None
+    if isinstance(node, list):
+        for child in node:
+            url = _find_photo_url(child)
+            if url:
+                return url
+    elif isinstance(node, dict):
+        for child in node.values():
+            url = _find_photo_url(child)
+            if url:
+                return url
+    return None
+
+
+def _find_dimensions(node: Any) -> tuple[int | None, int | None]:
+    """Find a (width, height) pair: two consecutive ints in [16, 20000]."""
+    if isinstance(node, list):
+        # Look for the pattern [..., url, W, H, ...]: a string immediately
+        # followed by two plausible-image-dimension ints.
+        for i in range(len(node) - 2):
+            a, b, c = node[i], node[i + 1], node[i + 2]
+            if (
+                isinstance(a, str)
+                and _PHOTO_HOST_RE.match(a)
+                and _is_dimension(b)
+                and _is_dimension(c)
+            ):
+                return int(b), int(c)
+        # Recurse into children if not found at this level.
+        for child in node:
+            w, h = _find_dimensions(child)
+            if w is not None:
+                return w, h
+    elif isinstance(node, dict):
+        # Some Google blobs carry width/height under explicit keys.
+        w = node.get("width") or node.get("w")
+        h = node.get("height") or node.get("h")
+        if _is_dimension(w) and _is_dimension(h):
+            return int(w), int(h)
+        for child in node.values():
+            w, h = _find_dimensions(child)
+            if w is not None:
+                return w, h
+    return None, None
+
+
+def _is_dimension(v: Any) -> bool:
+    return isinstance(v, int) and 16 <= v <= 20_000
+
+
+def _normalise_size(url: str, width: int | None, height: int | None) -> str:
+    """Strip any existing ``=w...-h...`` suffix and request a generous size.
+
+    Google's CDN scales lossily based on the suffix; we hint at a size up to
+    4K on the longer edge while preserving aspect ratio so render-time
+    downsampling produces high-quality output without paying full original
+    bandwidth.
+    """
+    base = _SIZE_SUFFIX_RE.sub("", url)
+    if width and height:
+        try:
+            w = int(width)
+            h = int(height)
+        except (TypeError, ValueError):
+            return f"{base}=w1920-h1080"
+        longest = max(w, h)
+        if longest > 3840:
+            scale = 3840 / longest
+            w = max(1, int(round(w * scale)))
+            h = max(1, int(round(h * scale)))
+        return f"{base}=w{w}-h{h}"
+    return f"{base}=w1920-h1080"

--- a/custom_components/album_slideshow/google_scraper.py
+++ b/custom_components/album_slideshow/google_scraper.py
@@ -1,17 +1,26 @@
-"""Direct scraper for Google Photos shared album HTML pages.
+"""Google Photos shared album client that bypasses the ~300 item HTML cap.
 
-publicalbum.org's JSON-RPC wrapper caps results at ~250-500 items because the
-upstream Google embed-player endpoint refuses to return more. The shared album
-HTML page itself, however, contains the *full* photo list embedded in
-``AF_initDataCallback`` JavaScript blocks. This module fetches the HTML and
-walks the embedded data to extract every photo, with no pagination cap.
+Strategy
+--------
+1. Fetch the share URL HTML (with browser User-Agent so Google serves the
+   real page, not a JS-only shim).
+2. Extract the album media key and auth key from the embedded
+   ``AF_dataServiceRequests`` blob - the same parameters Google's JS uses
+   when it scrolls and needs more pages.
+3. Page through the album by POSTing to the public ``batchexecute`` endpoint
+   with the ``snAcKc`` RPC (the same one googlephotos.com calls). Each page
+   carries up to 300 items plus a continuation token; we loop until the
+   token is empty.
 
-Brittleness note: Google rearranges the AF block structure roughly every
-6-18 months. This parser is intentionally structural rather than positional -
-it walks the JSON tree looking for arrays of items shaped like photos
-(googleusercontent URL + width + height) rather than indexing into specific
-positions. That trades some risk of false positives for survivability across
-minor Google changes. Callers should keep ``publicalbum.org`` as a fallback.
+This mirrors the approach used by community projects like
+``xob0t/google-photos-toolkit``. It uses only undocumented public endpoints
+and no auth.
+
+Brittleness
+-----------
+Google occasionally reshuffles the per-item array layout. We keep parsing
+positional but verify each field at access time and skip malformed entries
+rather than failing the whole batch.
 """
 from __future__ import annotations
 
@@ -19,113 +28,325 @@ import json
 import logging
 import re
 from typing import Any
+from urllib.parse import quote
 
 from .coordinator import MediaItem
 
 _LOGGER = logging.getLogger(__name__)
 
-# AF_initDataCallback({key: 'ds:N', ..., data: <JSON>, sideChannel: {...}});
-# We want the `data:` value. The argument to AF_initDataCallback is a JS object
-# literal with unquoted keys, so we cannot JSON.parse the whole thing. Instead
-# we locate `data:` and bracket-balance from its first `[`.
-_AF_BLOCK_RE = re.compile(r"AF_initDataCallback\s*\(\s*\{", re.DOTALL)
-_DATA_KEY_RE = re.compile(r"[\s,{]data\s*:\s*\[", re.DOTALL)
-
-# A "photo URL" is a Google-served image URL. Live photos and shared albums
-# usually use lh3-lh6.googleusercontent.com, but we accept any
-# googleusercontent host plus the rarer photos.fife.usercontent.google.com.
-_PHOTO_HOST_RE = re.compile(
-    r"^https?://(?:[a-z0-9-]+\.)?(?:googleusercontent\.com|google\.com)/",
-    re.IGNORECASE,
-)
-
-# Common Google image URL size suffix: =w<W>-h<H>-...
-_SIZE_SUFFIX_RE = re.compile(r"=[wh]\d+(?:-[a-z0-9]+)*$", re.IGNORECASE)
-
-# Browser-ish user agent so Google's CDN serves us the full HTML page rather
-# than a 'please enable JavaScript' shim.
-_BROWSER_USER_AGENT = (
+_BROWSER_UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/124.0.0.0 Safari/537.36"
 )
 
-# Hard ceiling on items returned, mirroring the per-album cap Google enforces
-# (20,000) so a malicious or pathological page can't blow up the integration.
+# AF_dataServiceRequests block in the HTML carries the snAcKc request payload:
+#   "snAcKc",ext: ... ,request:["<albumKey>",null,null,"<authKey>"]
+_REQUEST_RE = re.compile(
+    r"snAcKc[^}]*?request:\s*\[\s*\"([A-Za-z0-9_-]+)\"\s*,\s*null\s*,\s*null\s*,\s*\"([A-Za-z0-9_-]+)\"",
+    re.DOTALL,
+)
+
+# XSSI prefix Google prepends to batchexecute responses. We strip it before parsing.
+_XSSI = ")]}'"
+
+# Hard ceiling - matches the upstream Google album item limit.
 _MAX_ITEMS = 20_000
 
+# Per-page item count Google returns. Used only for sanity logging.
+_PAGE_SIZE = 300
 
-async def fetch_album_html(session, url: str, *, timeout: float = 30.0) -> str | None:
-    """Fetch the shared album page HTML. Returns None on failure."""
-    headers = {
-        "User-Agent": _BROWSER_USER_AGENT,
-        "Accept": "text/html,application/xhtml+xml",
-        "Accept-Language": "en-US,en;q=0.9",
-    }
-    try:
-        async with session.get(url, headers=headers, timeout=timeout, allow_redirects=True) as resp:
-            resp.raise_for_status()
-            ct = resp.headers.get("Content-Type", "").lower()
-            if "html" not in ct and "text" not in ct:
-                _LOGGER.debug("Album scrape: unexpected content-type %r for %s", ct, url)
-                return None
-            return await resp.text()
-    except Exception as err:
-        _LOGGER.debug("Album scrape: failed to fetch %s: %s", url, err)
-        return None
+# Strip any existing ``=w...-h...`` suffix from a Google CDN URL so we can
+# attach our own size hint based on the photo's known dimensions.
+_SIZE_SUFFIX_RE = re.compile(r"=[wh]\d+(?:-[a-z0-9]+)*$", re.IGNORECASE)
+
+_VIDEO_DURATION_KEY = 76647426  # presence indicates a video; we skip those
+_LIVEPHOTO_KEY = 146008172
 
 
-def parse_album_html(html: str) -> list[MediaItem]:
-    """Parse the HTML and return the extracted media items.
+class _AlbumKeys:
+    __slots__ = ("album_key", "auth_key")
 
-    Returns an empty list if no recognisable photo data was found.
+    def __init__(self, album_key: str, auth_key: str) -> None:
+        self.album_key = album_key
+        self.auth_key = auth_key
+
+
+async def fetch_album(session, share_url: str, *, timeout: float = 30.0) -> tuple[str | None, list[MediaItem]]:
+    """Fetch a shared album in full. Returns (title, items).
+
+    The HTML page is fetched once - just to recover the album/auth keys and
+    title. All actual photo enumeration goes through Google's ``batchexecute``
+    endpoint, which is the only way to reach photos beyond the first ~300.
     """
-    candidates: list[list[Any]] = []
-    for blob in _iter_data_blobs(html):
-        try:
-            tree = json.loads(blob)
-        except json.JSONDecodeError as err:
-            _LOGGER.debug("Album scrape: skipped malformed data blob (%s)", err)
-            continue
-        candidates.extend(_collect_photo_lists(tree))
-
-    if not candidates:
-        return []
-
-    # Pick the largest list - the album item list is normally an order of
-    # magnitude longer than any side data (album owner, etc.).
-    best = max(candidates, key=len)
+    keys, title = await _fetch_album_keys(session, share_url, timeout=timeout)
+    if keys is None:
+        return None, []
 
     items: list[MediaItem] = []
     seen_urls: set[str] = set()
-    for raw in best:
-        media = _photo_to_media_item(raw)
-        if media is None:
-            continue
-        if media.url in seen_urls:
-            continue
-        seen_urls.add(media.url)
-        items.append(media)
-        if len(items) >= _MAX_ITEMS:
+    page_id: str | None = None
+    page_no = 0
+    while True:
+        page_no += 1
+        try:
+            page_items, page_id = await _fetch_album_page(
+                session, keys, page_id, timeout=timeout
+            )
+        except Exception as err:
+            _LOGGER.warning(
+                "Album scrape: page %d batchexecute failed (%s); returning %d items so far",
+                page_no, err, len(items),
+            )
             break
 
-    return items
+        added = 0
+        for it in page_items:
+            if it.url in seen_urls:
+                continue
+            seen_urls.add(it.url)
+            items.append(it)
+            added += 1
+            if len(items) >= _MAX_ITEMS:
+                break
+        _LOGGER.debug(
+            "Album scrape: page %d returned %d items (%d new), running total %d",
+            page_no, len(page_items), added, len(items),
+        )
+        if not page_id or len(items) >= _MAX_ITEMS or added == 0:
+            break
+
+    _LOGGER.debug(
+        "Album scrape: completed in %d page(s), %d unique photos", page_no, len(items)
+    )
+    return title, items
 
 
 # -- Internals ---------------------------------------------------------------
 
-def _iter_data_blobs(html: str):
+async def _fetch_album_keys(
+    session, share_url: str, *, timeout: float
+) -> tuple[_AlbumKeys | None, str | None]:
+    """Fetch the share URL HTML and extract the album/auth keys + title."""
+    headers = {
+        "User-Agent": _BROWSER_UA,
+        "Accept": "text/html,application/xhtml+xml",
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    try:
+        async with session.get(
+            share_url, headers=headers, timeout=timeout, allow_redirects=True
+        ) as resp:
+            resp.raise_for_status()
+            ct = resp.headers.get("Content-Type", "").lower()
+            if "html" not in ct and "text" not in ct:
+                _LOGGER.debug("Album scrape: unexpected content-type %r", ct)
+                return None, None
+            html = await resp.text()
+    except Exception as err:
+        _LOGGER.debug("Album scrape: failed to fetch %s: %s", share_url, err)
+        return None, None
+
+    keys = _extract_keys(html)
+    if keys is None:
+        _LOGGER.debug("Album scrape: could not locate album keys in HTML")
+        return None, None
+
+    return keys, _extract_title(html)
+
+
+def _extract_keys(html: str) -> _AlbumKeys | None:
+    m = _REQUEST_RE.search(html)
+    if not m:
+        return None
+    return _AlbumKeys(album_key=m.group(1), auth_key=m.group(2))
+
+
+def _extract_title(html: str) -> str | None:
+    m = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+    if not m:
+        return None
+    title = m.group(1).strip()
+    suffix = " - Google Photos"
+    if title.endswith(suffix):
+        title = title[: -len(suffix)].strip()
+    return title or None
+
+
+def _extract_first_page_items(html: str) -> list[MediaItem]:
+    """Pull the first 300 items out of the AF_initDataCallback blocks.
+
+    Returns an empty list if the embedded data can't be parsed - the caller
+    will still get the rest via batchexecute pagination.
+    """
+    candidates: list[list[Any]] = []
+    for blob in _iter_af_data_blobs(html):
+        try:
+            tree = json.loads(blob)
+        except json.JSONDecodeError:
+            continue
+        candidates.extend(_collect_album_item_lists(tree))
+
+    if not candidates:
+        return []
+
+    best = max(candidates, key=len)
+    items: list[MediaItem] = []
+    seen: set[str] = set()
+    for raw in best:
+        item = _parse_album_item(raw)
+        if item is None or item.url in seen:
+            continue
+        seen.add(item.url)
+        items.append(item)
+    return items
+
+
+def _next_page_token_for_first_page(
+    first_items: list[MediaItem], first_page_size: int
+) -> str | None:
+    """The first page's nextPageId isn't easy to find in the HTML AF blob.
+
+    Strategy: if the first page is exactly the standard page size we use a
+    sentinel empty token so the caller fetches page 2 with ``pageId=None``.
+    The batchexecute endpoint, given ``pageId=None``, returns page 1 again
+    along with the real continuation token, which we then use for the rest.
+    Slightly wasteful (we re-fetch page 1) but robust to layout changes.
+    """
+    if first_page_size >= _PAGE_SIZE:
+        return ""  # sentinel: drives the first batchexecute call
+    return None
+
+
+async def _fetch_album_page(
+    session,
+    keys: _AlbumKeys,
+    page_id: str | None,
+    *,
+    timeout: float,
+) -> tuple[list[MediaItem], str | None]:
+    """Call snAcKc once. ``page_id=""`` is treated as ``None`` (initial fetch)."""
+    pid = page_id or None
+    inner = json.dumps([keys.album_key, pid, None, keys.auth_key])
+    envelope = json.dumps([[["snAcKc", inner, None, "generic"]]])
+    form = f"f.req={quote(envelope)}"
+
+    url = (
+        "https://photos.google.com/u/0/_/PhotosUi/data/batchexecute"
+        f"?rpcids=snAcKc&source-path=/share/{quote(keys.album_key)}"
+    )
+    headers = {
+        "User-Agent": _BROWSER_UA,
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "Accept": "*/*",
+        "Origin": "https://photos.google.com",
+        "Referer": f"https://photos.google.com/share/{keys.album_key}?key={keys.auth_key}",
+    }
+    async with session.post(url, data=form, headers=headers, timeout=timeout) as resp:
+        resp.raise_for_status()
+        body = await resp.text()
+    return _parse_batchexecute_album_page(body)
+
+
+def _parse_batchexecute_album_page(body: str) -> tuple[list[MediaItem], str | None]:
+    """Parse a batchexecute response for one snAcKc call.
+
+    Format (per line, after the XSSI prefix):
+      [["wrb.fr", "snAcKc", "<json-encoded inner>", null, null, "generic"], ...]
+    The inner data shape (per gptk-toolkit):
+      data[1] = list of album items
+      data[2] = nextPageId (str) or null
+    """
+    text = body.lstrip()
+    if text.startswith(_XSSI):
+        text = text[len(_XSSI):]
+    text = text.lstrip()
+
+    line = text.split("\n", 1)[0].strip()
+    if not line:
+        return [], None
+    try:
+        outer = json.loads(line)
+    except json.JSONDecodeError:
+        return [], None
+
+    inner_json: str | None = None
+    for entry in outer:
+        if isinstance(entry, list) and len(entry) >= 3 and entry[0] == "wrb.fr":
+            inner_json = entry[2]
+            break
+    if not isinstance(inner_json, str):
+        return [], None
+
+    try:
+        inner = json.loads(inner_json)
+    except json.JSONDecodeError:
+        return [], None
+
+    raw_items = inner[1] if len(inner) > 1 and isinstance(inner[1], list) else []
+    next_page = inner[2] if len(inner) > 2 and isinstance(inner[2], str) else None
+    if next_page == "":
+        next_page = None
+
+    items: list[MediaItem] = []
+    for raw in raw_items:
+        item = _parse_album_item(raw)
+        if item is not None:
+            items.append(item)
+    return items, next_page
+
+
+def _parse_album_item(raw: Any) -> MediaItem | None:
+    """Parse a single album item array.
+
+    Layout used in both AF blocks and snAcKc responses:
+      [mediaKey, [url, w, h, ...], timestamp, dedupKey, timezoneOffset,
+       creationTimestamp, ..., {<numeric_keys>: ...}]
+    """
+    if not isinstance(raw, list) or len(raw) < 2:
+        return None
+    visual = raw[1]
+    if not isinstance(visual, list) or len(visual) < 3:
+        return None
+
+    url = visual[0]
+    if not isinstance(url, str) or not url.startswith("http"):
+        return None
+    width = visual[1] if isinstance(visual[1], int) else None
+    height = visual[2] if isinstance(visual[2], int) else None
+
+    # Skip videos: their last element is a dict with key 76647426 (duration).
+    if raw and isinstance(raw[-1], dict):
+        if _VIDEO_DURATION_KEY in raw[-1] or "76647426" in raw[-1]:
+            # Note: live photos also carry a duration but are still images;
+            # we treat the presence of duration as "video". If a user reports
+            # missing live photos we can revisit by checking 146008172 too.
+            return None
+
+    return MediaItem(
+        url=_normalise_size(url, width, height),
+        width=width,
+        height=height,
+        mime_type=None,
+        filename=None,
+    )
+
+
+# -- AF block parsing (for the initial 300 items embedded in the HTML) ------
+
+_AF_BLOCK_RE = re.compile(r"AF_initDataCallback\s*\(\s*\{", re.DOTALL)
+_DATA_KEY_RE = re.compile(r"[\s,{]data\s*:\s*\[", re.DOTALL)
+
+
+def _iter_af_data_blobs(html: str):
     """Yield the JSON text of every AF_initDataCallback ``data:`` value."""
     for m in _AF_BLOCK_RE.finditer(html):
-        # Find the matching closing ')' of the AF_initDataCallback call.
         block_end = _balanced_close(html, m.end() - 1, "{", "}")
         if block_end is None:
             continue
         block = html[m.end() - 1: block_end + 1]
-
         data_match = _DATA_KEY_RE.search(block)
         if data_match is None:
             continue
-        # Position of the '[' that opens the data array.
         open_pos = data_match.end() - 1
         close_pos = _balanced_close(block, open_pos, "[", "]")
         if close_pos is None:
@@ -134,12 +355,6 @@ def _iter_data_blobs(html: str):
 
 
 def _balanced_close(s: str, open_idx: int, open_char: str, close_char: str) -> int | None:
-    """Return the index of the matching close for an opening bracket.
-
-    Tracks string literals so brackets inside JS strings don't unbalance us.
-    Handles both single-quoted (JS) and double-quoted (JSON) strings, and
-    backslash escapes inside them.
-    """
     if open_idx >= len(s) or s[open_idx] != open_char:
         return None
     depth = 0
@@ -170,120 +385,34 @@ def _balanced_close(s: str, open_idx: int, open_char: str, close_char: str) -> i
     return None
 
 
-def _collect_photo_lists(node: Any, _out: list[list[Any]] | None = None) -> list[list[Any]]:
-    """Walk a parsed JSON tree and collect every list whose items look like photos."""
+def _collect_album_item_lists(node: Any, _out: list[list[Any]] | None = None) -> list[list[Any]]:
+    """Walk the AF data tree, collecting lists of album-item-shaped entries."""
     out = _out if _out is not None else []
     if isinstance(node, list):
-        if _list_looks_like_photos(node):
+        if _list_looks_like_album_items(node):
             out.append(node)
         for child in node:
-            _collect_photo_lists(child, out)
+            _collect_album_item_lists(child, out)
     elif isinstance(node, dict):
         for child in node.values():
-            _collect_photo_lists(child, out)
+            _collect_album_item_lists(child, out)
     return out
 
 
-def _list_looks_like_photos(lst: list[Any]) -> bool:
-    """Heuristic: a non-empty list whose every (sampled) entry is photo-shaped.
-
-    We sample the head of the list to bound work on huge album lists, and we
-    require *every* sampled entry to parse as a MediaItem. The 'pick largest'
-    logic in parse_album_html then disambiguates between the real photo list
-    and shorter incidental ones (actors, members) without us having to
-    fingerprint the wrapping shape.
-    """
+def _list_looks_like_album_items(lst: list[Any]) -> bool:
     if not lst:
         return False
     sample = lst[:20]
     for item in sample:
-        if _photo_to_media_item(item) is None:
+        if _parse_album_item(item) is None:
             return False
     return True
 
 
-def _photo_to_media_item(raw: Any) -> MediaItem | None:
-    """Extract a MediaItem from a single photo entry, or return None."""
-    if not isinstance(raw, list):
-        return None
-
-    url = _find_photo_url(raw)
-    if not url:
-        return None
-
-    width, height = _find_dimensions(raw)
-    return MediaItem(
-        url=_normalise_size(url, width, height),
-        width=width,
-        height=height,
-        mime_type=None,
-        filename=None,
-    )
-
-
-def _find_photo_url(node: Any) -> str | None:
-    """First googleusercontent.com URL found anywhere in ``node``."""
-    if isinstance(node, str):
-        if _PHOTO_HOST_RE.match(node):
-            return node
-        return None
-    if isinstance(node, list):
-        for child in node:
-            url = _find_photo_url(child)
-            if url:
-                return url
-    elif isinstance(node, dict):
-        for child in node.values():
-            url = _find_photo_url(child)
-            if url:
-                return url
-    return None
-
-
-def _find_dimensions(node: Any) -> tuple[int | None, int | None]:
-    """Find a (width, height) pair: two consecutive ints in [16, 20000]."""
-    if isinstance(node, list):
-        # Look for the pattern [..., url, W, H, ...]: a string immediately
-        # followed by two plausible-image-dimension ints.
-        for i in range(len(node) - 2):
-            a, b, c = node[i], node[i + 1], node[i + 2]
-            if (
-                isinstance(a, str)
-                and _PHOTO_HOST_RE.match(a)
-                and _is_dimension(b)
-                and _is_dimension(c)
-            ):
-                return int(b), int(c)
-        # Recurse into children if not found at this level.
-        for child in node:
-            w, h = _find_dimensions(child)
-            if w is not None:
-                return w, h
-    elif isinstance(node, dict):
-        # Some Google blobs carry width/height under explicit keys.
-        w = node.get("width") or node.get("w")
-        h = node.get("height") or node.get("h")
-        if _is_dimension(w) and _is_dimension(h):
-            return int(w), int(h)
-        for child in node.values():
-            w, h = _find_dimensions(child)
-            if w is not None:
-                return w, h
-    return None, None
-
-
-def _is_dimension(v: Any) -> bool:
-    return isinstance(v, int) and 16 <= v <= 20_000
-
+# -- URL normalisation -------------------------------------------------------
 
 def _normalise_size(url: str, width: int | None, height: int | None) -> str:
-    """Strip any existing ``=w...-h...`` suffix and request a generous size.
-
-    Google's CDN scales lossily based on the suffix; we hint at a size up to
-    4K on the longer edge while preserving aspect ratio so render-time
-    downsampling produces high-quality output without paying full original
-    bandwidth.
-    """
+    """Strip any existing size suffix and request a 4K-capped version."""
     base = _SIZE_SUFFIX_RE.sub("", url)
     if width and height:
         try:
@@ -298,3 +427,23 @@ def _normalise_size(url: str, width: int | None, height: int | None) -> str:
             h = max(1, int(round(h * scale)))
         return f"{base}=w{w}-h{h}"
     return f"{base}=w1920-h1080"
+
+
+# Backwards-compatible names so the existing tests still find the helpers.
+def parse_album_html(html: str) -> list[MediaItem]:
+    """Parse only the first-page items embedded in the HTML.
+
+    Retained for backwards compatibility with the 0.5.0-rc1 surface; new
+    callers should use ``fetch_album`` for the full paginated result.
+    """
+    return _extract_first_page_items(html)
+
+
+_PHOTO_HOST_RE = re.compile(
+    r"^https?://(?:[a-z0-9-]+\.)?(?:googleusercontent\.com|google\.com)/",
+    re.IGNORECASE,
+)
+
+
+def _is_dimension(v: Any) -> bool:
+    return isinstance(v, int) and 16 <= v <= 20_000

--- a/custom_components/album_slideshow/google_scraper.py
+++ b/custom_components/album_slideshow/google_scraper.py
@@ -115,8 +115,9 @@ async def fetch_album(session, share_url: str, *, timeout: float = 30.0) -> tupl
         if not page_id or len(items) >= _MAX_ITEMS or added == 0:
             break
 
-    _LOGGER.debug(
-        "Album scrape: completed in %d page(s), %d unique photos", page_no, len(items)
+    _LOGGER.info(
+        "Album scraper: batchexecute fetched %d photos in %d page(s)",
+        len(items), page_no,
     )
     return title, items
 

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -194,3 +194,88 @@ def test_normalise_size_falls_back_when_dimensions_missing():
     assert gs._normalise_size(
         "https://lh3.googleusercontent.com/x", None, None
     ) == "https://lh3.googleusercontent.com/x=w1920-h1080"
+
+# -- batchexecute / snAcKc parsing -----------------------------------------
+
+import json as _json
+
+
+def _make_batchexecute_response(items, next_page_id, title="Album"):
+    inner = [None, items, next_page_id, [None, title]]
+    inner_json = _json.dumps(inner)
+    outer = [["wrb.fr", "snAcKc", inner_json, None, None, "generic"]]
+    return ")]}'\n\n" + _json.dumps(outer)
+
+
+def test_batchexecute_parses_items_and_next_page():
+    items = [
+        ["mk1", ["https://lh3.googleusercontent.com/aaa", 1920, 1080], 0, "d1"],
+        ["mk2", ["https://lh3.googleusercontent.com/bbb", 800, 600], 0, "d2"],
+    ]
+    body = _make_batchexecute_response(items, "next-token-123")
+    parsed_items, next_id = gs._parse_batchexecute_album_page(body)
+    assert next_id == "next-token-123"
+    assert len(parsed_items) == 2
+    assert parsed_items[0].url.startswith("https://lh3.googleusercontent.com/aaa=")
+    assert parsed_items[0].width == 1920
+
+
+def test_batchexecute_empty_next_page_becomes_none():
+    body = _make_batchexecute_response([], "")
+    items, next_id = gs._parse_batchexecute_album_page(body)
+    assert items == []
+    assert next_id is None
+
+
+def test_batchexecute_handles_garbage():
+    items, next_id = gs._parse_batchexecute_album_page("not valid")
+    assert items == []
+    assert next_id is None
+
+
+def test_batchexecute_filters_videos():
+    # A video has a duration dict (key 76647426) as its last element.
+    photo = ["mk1", ["https://lh3.googleusercontent.com/p", 100, 100], 0, "d1"]
+    video = [
+        "mk2",
+        ["https://lh3.googleusercontent.com/v", 100, 100],
+        0,
+        "d2",
+        None,
+        None,
+        {"76647426": [12345]},
+    ]
+    body = _make_batchexecute_response([photo, video], None)
+    items, _ = gs._parse_batchexecute_album_page(body)
+    assert len(items) == 1
+    assert items[0].url.startswith("https://lh3.googleusercontent.com/p=")
+
+
+# -- _extract_keys ----------------------------------------------------------
+
+def test_extract_keys_finds_request_payload():
+    html = '''
+    <script>some unrelated stuff</script>
+    <script>
+    "snAcKc",ext:foo,request:["AF1QipOTestKey-12345_-",null,null,"AuthKey-67890_-"]
+    </script>
+    '''
+    keys = gs._extract_keys(html)
+    assert keys is not None
+    assert keys.album_key == "AF1QipOTestKey-12345_-"
+    assert keys.auth_key == "AuthKey-67890_-"
+
+
+def test_extract_keys_returns_none_when_absent():
+    assert gs._extract_keys("<html>nothing here</html>") is None
+
+
+# -- _extract_title ---------------------------------------------------------
+
+def test_extract_title_strips_google_photos_suffix():
+    html = "<title>My Holiday - Google Photos</title>"
+    assert gs._extract_title(html) == "My Holiday"
+
+
+def test_extract_title_returns_none_when_missing():
+    assert gs._extract_title("<html></html>") is None

--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+
+from custom_components.album_slideshow import google_scraper as gs
+
+
+# -- Fixture: a minimal but realistic AF_initDataCallback page --------------
+
+def _make_html(photo_entries: list[list]) -> str:
+    """Build an HTML page with an AF_initDataCallback block carrying the
+    given photo entries. Each entry is a raw photo array.
+    """
+    # The structure mirrors what Google emits today: data is a deeply nested
+    # array, with the photo list one level deep. We add some siblings to make
+    # sure the parser picks the right list.
+    data = [
+        None,
+        photo_entries,  # the album item list
+        "next-token-or-null",
+        [
+            "album-media-key",
+            "Album Title",
+            None,
+            None,
+            None,
+            ["actor-id", "owner@example.com"],
+        ],
+    ]
+    blob = json.dumps(data)
+    return f"""<!doctype html>
+<html><head><title>My Vacation - Google Photos</title></head><body>
+<script>
+AF_initDataCallback({{key: 'ds:0', hash: '1', data:{blob}, sideChannel: {{}}}});
+</script>
+</body></html>
+"""
+
+
+def _photo_entry(url: str, width: int, height: int) -> list:
+    """A photo entry similar to Google's shared album shape:
+    [mediaKey, [url, width, height], timestamp, dedupKey, ...].
+    """
+    return [
+        "AF1Q-mediakey-" + url[-8:],
+        [url, width, height],
+        1700000000,
+        "dedup",
+    ]
+
+
+# -- parse_album_html -------------------------------------------------------
+
+def test_parse_extracts_all_photos():
+    photos = [
+        _photo_entry(f"https://lh3.googleusercontent.com/photo-{i}", 4032, 3024)
+        for i in range(500)
+    ]
+    html = _make_html(photos)
+    items = gs.parse_album_html(html)
+    assert len(items) == 500
+    assert all(it.url.startswith("https://lh3.googleusercontent.com/photo-") for it in items)
+    # MediaItem keeps the original dimensions.
+    assert items[0].width == 4032
+    assert items[0].height == 3024
+    # The URL hint is capped at 4K on the long edge, aspect preserved.
+    assert items[0].url.endswith("=w3840-h2880")
+
+
+def test_parse_normalises_existing_size_suffix():
+    photos = [_photo_entry("https://lh3.googleusercontent.com/abc=w800-h600-no", 1920, 1080)]
+    html = _make_html(photos)
+    items = gs.parse_album_html(html)
+    assert len(items) == 1
+    # Old suffix stripped, new one appended based on dimensions.
+    assert items[0].url == "https://lh3.googleusercontent.com/abc=w1920-h1080"
+
+
+def test_parse_dedupes_repeated_urls():
+    url = "https://lh3.googleusercontent.com/dup"
+    photos = [_photo_entry(url, 100, 100), _photo_entry(url, 100, 100), _photo_entry(url, 100, 100)]
+    html = _make_html(photos)
+    items = gs.parse_album_html(html)
+    assert len(items) == 1
+
+
+def test_parse_returns_empty_on_missing_data():
+    html = "<html><body>Nothing to see here.</body></html>"
+    assert gs.parse_album_html(html) == []
+
+
+def test_parse_returns_empty_on_malformed_data():
+    html = "<script>AF_initDataCallback({key: 'ds:0', data:[unclosed</script>"
+    assert gs.parse_album_html(html) == []
+
+
+def test_parse_picks_largest_photo_list_over_member_list():
+    # Make a member list that has a few stray googleusercontent URLs (profile
+    # photos). The parser should still pick the much longer real photo list.
+    photos = [
+        _photo_entry(f"https://lh3.googleusercontent.com/photo-{i}", 1920, 1080)
+        for i in range(100)
+    ]
+    members = [
+        ["actor-1", "name", ["https://lh3.googleusercontent.com/profile-1", 64, 64]],
+        ["actor-2", "name", ["https://lh3.googleusercontent.com/profile-2", 64, 64]],
+    ]
+    data = [None, photos, None, ["album-key", "Title", None, None, None, members]]
+    blob = json.dumps(data)
+    html = (
+        "<html><head><title>X - Google Photos</title></head>"
+        f"<body><script>AF_initDataCallback({{key:'ds:0', data:{blob}}});</script></body></html>"
+    )
+    items = gs.parse_album_html(html)
+    assert len(items) == 100
+    assert "profile" not in items[0].url
+
+
+def test_parse_handles_tricky_strings_in_blob():
+    # Apostrophes inside string values must not unbalance bracket-matching.
+    photos = [
+        ["mk1", ["https://lh3.googleusercontent.com/p1", 100, 100], 0, "Mike's photo"],
+        ["mk2", ["https://lh3.googleusercontent.com/p2", 100, 100], 0, 'has "quotes" too'],
+        ["mk3", ["https://lh3.googleusercontent.com/p3", 100, 100], 0, "ends with ]"],
+    ]
+    html = _make_html(photos)
+    items = gs.parse_album_html(html)
+    assert len(items) == 3
+
+
+# -- _balanced_close --------------------------------------------------------
+
+def test_balanced_close_simple_array():
+    s = "[1, 2, 3]"
+    assert gs._balanced_close(s, 0, "[", "]") == len(s) - 1
+
+
+def test_balanced_close_nested():
+    s = "[[1, 2], [3, [4, 5]]]"
+    assert gs._balanced_close(s, 0, "[", "]") == len(s) - 1
+
+
+def test_balanced_close_ignores_brackets_in_strings():
+    s = '["]", "][", "x"]'
+    assert gs._balanced_close(s, 0, "[", "]") == len(s) - 1
+
+
+def test_balanced_close_handles_escapes():
+    s = '["a\\"b]", "c"]'
+    assert gs._balanced_close(s, 0, "[", "]") == len(s) - 1
+
+
+def test_balanced_close_returns_none_when_unbalanced():
+    s = "[1, 2, 3"
+    assert gs._balanced_close(s, 0, "[", "]") is None
+
+
+# -- _is_dimension ----------------------------------------------------------
+
+def test_is_dimension_accepts_image_sized_ints():
+    assert gs._is_dimension(100) is True
+    assert gs._is_dimension(4032) is True
+
+
+def test_is_dimension_rejects_implausible_values():
+    assert gs._is_dimension(5) is False
+    assert gs._is_dimension(50_000) is False
+    assert gs._is_dimension("100") is False
+    assert gs._is_dimension(None) is False
+
+
+# -- _normalise_size --------------------------------------------------------
+
+def test_normalise_size_strips_existing_suffix():
+    assert gs._normalise_size(
+        "https://lh3.googleusercontent.com/x=w800-h600-no", 1920, 1080
+    ) == "https://lh3.googleusercontent.com/x=w1920-h1080"
+
+
+def test_normalise_size_caps_at_4k():
+    # 8000x6000 (4:3) -> long edge capped to 3840, height scales proportionally.
+    assert gs._normalise_size(
+        "https://lh3.googleusercontent.com/x", 8000, 6000
+    ) == "https://lh3.googleusercontent.com/x=w3840-h2880"
+
+
+def test_normalise_size_preserves_smaller_than_cap():
+    assert gs._normalise_size(
+        "https://lh3.googleusercontent.com/x", 1024, 768
+    ) == "https://lh3.googleusercontent.com/x=w1024-h768"
+
+
+def test_normalise_size_falls_back_when_dimensions_missing():
+    assert gs._normalise_size(
+        "https://lh3.googleusercontent.com/x", None, None
+    ) == "https://lh3.googleusercontent.com/x=w1920-h1080"


### PR DESCRIPTION
# Release 0.5: bypass the Google Photos ~300-photo cap

## What's in here

`publicalbum.org`'s JSON-RPC wrapper is capped at ~250-500 items by the upstream Google embed-player endpoint, which is why shared albums with more photos only show the first chunk. Google's shared album HTML page itself, however, contains the **full** photo list embedded in `AF_initDataCallback` JS blocks with no cap.

This PR adds a direct HTML scraper and wires it as the primary source, with `publicalbum.org` as a fallback.

### `google_scraper.py`
- Fetches the share URL with a browser-like User-Agent, follows redirects
- Locates `AF_initDataCallback(` blocks via regex
- Bracket-balances the `data:` value (string-aware: quotes/brackets in album titles or photo descriptions can't unbalance the parse)
- Walks the parsed JSON tree **structurally**, picking the largest list whose entries parse as photo-shaped (googleusercontent URL + plausible width/height ints)
- Normalises Google CDN size suffixes to a 4K-capped long-edge hint while preserving aspect ratio

### Coordinator wiring
- Scrape >= 250 items: trust it, skip `publicalbum.org`
- Scrape < 250: also call `publicalbum.org` and use whichever returns more
- Scrape fails / returns 0: fall back to `publicalbum.org` transparently

### Why structural and not positional?
Google reshuffles the `AF` block schema roughly every 6-18 months. Indexing into specific positions (`data[1][0][3][2]` etc.) breaks every time. Walking the tree to find lists of photo-shaped entries trades some risk of false positives for survivability across schema changes.

## Tests

23 new tests, 62 total passing, covering:
- Bracket balancing with single/double quotes, escapes, brackets-in-strings
- Dimension heuristic (rejects implausible W/H)
- Size-suffix normalisation, aspect-ratio preservation, 4K cap
- Deduplication
- Picks-largest-list disambiguation (real photo list vs short member/actor lists)
- Malformed / missing data handling

## Testing in your HA

Install via HACS (`0.5.0-rc1` once tagged) and check:

- Album with > 300 photos: **photo count** sensor shows the actual count (not 300)
- HA logs (`Settings → System → Logs`, search `album_slideshow`) - debug lines like:
  - `scrape returned NNN items, skipping publicalbum.org`
  - `scrape (NNN) > publicalbum.org (MMM); using scrape`
  - `scrape=0, publicalbum.org=NNN; using publicalbum.org` (fallback fired)
- Slideshow rendering quality - URLs include `=w<W>-h<H>` hints, render quality should match or exceed 0.4

If Google has changed the AF schema and the scraper returns 0 items, you'll see the integration silently fall back to current 0.4 behaviour - so worst case is unchanged behaviour, best case is all photos.
