### PR TITLE
0.7: Brightwheel provider (daycare photos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All behavior is exposed as Home Assistant entities. Adjust everything live witho
 
 ### 🖼 Image Sources
 - Google Photos shared albums
+- **Brightwheel** guardian accounts (photos shared by your child's daycare/preschool)
 - Local folder paths
 - NAS mounted directories
 - Optional recursive scanning
@@ -231,6 +232,16 @@ When transparency is used, the integration outputs PNG to preserve alpha.
 - Internet connection required
 - Relies on Google's public web endpoints; if Google changes them, the integration falls back to a 300-photo limit until the scraper is updated
 - The last successful album fetch is cached to disk; if a refresh fails or returns no photos, the slideshow keeps running with the cached list
+
+### Brightwheel
+
+- Uses Brightwheel's private REST API; **not officially supported** by Brightwheel and may break if they change endpoints
+- Sign in with the same email/password you use in the Brightwheel app; a one-time 6-digit code is emailed to you to complete login
+- Sessions are persisted across Home Assistant restarts but expire after a few weeks; you will be prompted to re-authenticate via a Repair card when that happens
+- Photo URLs are short-lived signed S3 links; setting **Album refresh** lower than 6 hours is recommended (default 24 hours is fine if you only watch the slideshow occasionally)
+- Videos posted to Brightwheel are skipped (photos only)
+- Lookback range is configurable on setup (default: 365 days; set to 0 to fetch the entire history). Brightwheel guardian accounts can hold years of photos, so a tighter window keeps the playlist fast
+- Re-authentication carries the original entity ids and settings forward
 
 ### General
 

--- a/custom_components/album_slideshow/brightwheel_scraper.py
+++ b/custom_components/album_slideshow/brightwheel_scraper.py
@@ -149,36 +149,26 @@ def _restore_cookies(jar: aiohttp.CookieJar, cookies: list[dict[str, str]]) -> N
             _LOGGER.debug("Brightwheel: cookie restore failed for %s: %s", url_str, err)
 
 
-async def _fetch_csrf(session: aiohttp.ClientSession) -> str:
-    """Hit /api/sessions/start to obtain a fresh CSRF token + cookie."""
-    url = f"{BRIGHTWHEEL_BASE}/api/sessions/start"
-    async with async_timeout.timeout(_LOGIN_TIMEOUT):
-        async with session.get(url, headers=_default_headers()) as resp:
-            if resp.status >= 400:
-                raise BrightwheelError(f"CSRF bootstrap failed: HTTP {resp.status}")
-            try:
-                payload = await resp.json(content_type=None)
-            except Exception:
-                payload = {}
+async def _read_text(resp) -> str:
+    """Best-effort body fetch for diagnostics. Trims to 500 chars."""
+    try:
+        text = await resp.text()
+    except Exception:
+        return ""
+    return text[:500]
 
-    token = ""
-    if isinstance(payload, dict):
-        token = (
-            payload.get("csrf")
-            or payload.get("csrf_token")
-            or payload.get("authenticity_token")
-            or ""
-        )
-    if not token:
-        # Fall back to the cookie value Brightwheel sets on the bootstrap.
-        for cookie_name in ("csrf-token", "_brightwheel_csrf"):
-            cookie = session.cookie_jar.filter_cookies(BRIGHTWHEEL_BASE).get(cookie_name)
-            if cookie:
-                token = cookie.value
-                break
-    if not token:
-        raise BrightwheelError("Brightwheel did not return a CSRF token")
-    return token
+
+def _extract_csrf_from_jar(jar) -> str:
+    """Pull a CSRF cookie out of the jar if Brightwheel set one."""
+    try:
+        morsels = jar.filter_cookies(BRIGHTWHEEL_BASE)
+    except Exception:
+        return ""
+    for name in ("csrf-token", "_brightwheel_csrf", "x-csrf-token", "XSRF-TOKEN"):
+        cookie = morsels.get(name)
+        if cookie:
+            return cookie.value
+    return ""
 
 
 async def login(
@@ -190,45 +180,88 @@ async def login(
 ) -> BrightwheelSession:
     """Authenticate against Brightwheel.
 
+    Brightwheel's web app uses device-aware auth: a fresh device must
+    confirm with a 6-digit code emailed to the guardian. Sending the
+    credentials returns a 2FA challenge (HTTP 412 or a JSON flag); the
+    code is then submitted to ``PATCH /api/v1/sessions`` (or POST to the
+    same path on some deployments).
+
     Raises :class:`BrightwheelTwoFactorRequired` after the first call when
     a code is needed; the caller should prompt the user and call again
     with ``code`` set.
     """
-    csrf_token = await _fetch_csrf(session)
+    url = f"{BRIGHTWHEEL_BASE}/api/v1/sessions"
 
     if code:
-        # Final step: include the 2FA code.
-        url = f"{BRIGHTWHEEL_BASE}/api/v1/sessions"
-        body = {
-            "user": {"email": email, "password": password, "2fa_code": code},
-        }
+        method = "PATCH"
+        body = {"session": {"otp_code": code}}
     else:
-        # First step: validate creds, may trigger a 2FA email.
-        url = f"{BRIGHTWHEEL_BASE}/api/v1/sessions/start"
-        body = {"user": {"email": email, "password": password}}
+        method = "POST"
+        body = {
+            "session": {
+                "email": email,
+                "password": password,
+            }
+        }
+
+    csrf_token = _extract_csrf_from_jar(session.cookie_jar)
+    headers = _default_headers(csrf_token)
+
+    _LOGGER.debug(
+        "Brightwheel: %s %s body-keys=%s csrf=%s",
+        method,
+        url,
+        list(body.get("session", {}).keys()),
+        "yes" if csrf_token else "no",
+    )
 
     async with async_timeout.timeout(_LOGIN_TIMEOUT):
-        async with session.post(url, json=body, headers=_default_headers(csrf_token)) as resp:
+        request_ctx = session.request(method, url, json=body, headers=headers)
+        async with request_ctx as resp:
             status = resp.status
+            text = await _read_text(resp)
             try:
                 payload = await resp.json(content_type=None)
             except Exception:
-                payload = {}
+                payload = None
+
+    _LOGGER.debug(
+        "Brightwheel: %s %s -> %d (body[:200]=%r)",
+        method,
+        url,
+        status,
+        text[:200],
+    )
+
+    # 412 Precondition Failed is Brightwheel's signal that 2FA is required.
+    if status == 412 or (
+        isinstance(payload, dict)
+        and (
+            payload.get("2fa_code_required")
+            or payload.get("otp_required")
+            or payload.get("requires_otp")
+            or (payload.get("error") or "").lower() in {"otp_required", "2fa_required"}
+        )
+    ):
+        raise BrightwheelTwoFactorRequired(
+            "Brightwheel emailed a 6-digit verification code"
+        )
 
     if status in (401, 403):
         raise BrightwheelAuthRequired(
             f"Brightwheel rejected credentials (HTTP {status})"
         )
     if status >= 400:
-        raise BrightwheelError(f"Brightwheel login failed: HTTP {status}")
-
-    if isinstance(payload, dict) and payload.get("2fa_code_required"):
-        # No session cookie yet - bubble up so the config flow can prompt.
-        raise BrightwheelTwoFactorRequired(
-            "Brightwheel emailed a 6-digit verification code"
+        # Surface a snippet of the body so unexpected statuses are diagnosable.
+        snippet = text[:200].replace("\n", " ")
+        raise BrightwheelError(
+            f"Brightwheel login failed: HTTP {status} body={snippet!r}"
         )
 
-    # Success: return the cookie jar + csrf for persistence.
+    # Success: refresh the CSRF token from any cookie Brightwheel just set
+    # (the response will have rotated it).
+    csrf_token = _extract_csrf_from_jar(session.cookie_jar) or csrf_token
+
     return BrightwheelSession(
         csrf_token=csrf_token,
         cookies=_serialise_cookies(session.cookie_jar),
@@ -242,15 +275,24 @@ async def _get_json(
 ) -> Any:
     async with async_timeout.timeout(_FETCH_TIMEOUT):
         async with session.get(url, headers=_default_headers(csrf_token)) as resp:
-            if resp.status in (401, 403):
+            status = resp.status
+            text = await _read_text(resp)
+            _LOGGER.debug("Brightwheel: GET %s -> %d (body[:200]=%r)", url, status, text[:200])
+            if status in (401, 403):
                 raise BrightwheelAuthRequired(
-                    f"Brightwheel session expired (HTTP {resp.status})"
+                    f"Brightwheel session expired (HTTP {status})"
                 )
-            if resp.status >= 400:
+            if status >= 400:
+                snippet = text[:200].replace("\n", " ")
                 raise BrightwheelError(
-                    f"Brightwheel API error {resp.status} on {url}"
+                    f"Brightwheel API error {status} on {url} body={snippet!r}"
                 )
-            return await resp.json(content_type=None)
+            try:
+                return await resp.json(content_type=None)
+            except Exception as err:
+                raise BrightwheelError(
+                    f"Brightwheel returned non-JSON body on {url}: {err}"
+                ) from err
 
 
 async def fetch_guardian_id(

--- a/custom_components/album_slideshow/brightwheel_scraper.py
+++ b/custom_components/album_slideshow/brightwheel_scraper.py
@@ -1,0 +1,487 @@
+"""Brightwheel media scraper.
+
+Brightwheel does not publish a public API. This module talks to the
+internal REST API used by the web/mobile app at
+``schools.mybrightwheel.com/api/v1/...``.
+
+Auth flow (reverse-engineered, may change without notice):
+
+1. ``GET  /api/sessions/start``   - sets a CSRF cookie, returns CSRF token
+2. ``POST /api/v1/sessions/start`` with email+password
+   - 200 with ``2fa_code_required: true``  -> Brightwheel emails a 6-digit
+     code; user enters it in the config flow
+   - 200 with session info                 -> already trusted (rare)
+3. ``POST /api/v1/sessions``      with email+password+code
+   -> sets ``_brightwheel_v2`` session cookie
+
+Once authenticated:
+
+* ``GET /api/v1/users/me``                              -> guardian id
+* ``GET /api/v1/guardians/{id}/students``               -> student ids
+* ``GET /api/v1/students/{id}/activities?action_type=ac_photo,ac_video``
+                                                        -> paginated
+                                                           activities
+
+Activity payloads expose ``media.image_url`` / ``video_url`` which are
+signed S3 URLs that expire after a few hours. The coordinator therefore
+re-fetches the metadata more aggressively than for static albums.
+
+A :class:`BrightwheelAuthRequired` exception is raised whenever the API
+returns 401/403; the integration surfaces that as a HA reauth flow so
+the user can re-enter the 2FA code.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote
+
+import aiohttp
+import async_timeout
+
+from .const import (
+    BRIGHTWHEEL_BASE,
+    BRIGHTWHEEL_CLIENT_NAME,
+    BRIGHTWHEEL_CLIENT_VERSION,
+    BRIGHTWHEEL_DEFAULT_PAGE_SIZE,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_LOGIN_TIMEOUT = 30
+_FETCH_TIMEOUT = 60
+
+
+class BrightwheelError(Exception):
+    """Base class for Brightwheel API errors."""
+
+
+class BrightwheelAuthRequired(BrightwheelError):
+    """Authentication is missing or has expired (401/403)."""
+
+
+class BrightwheelTwoFactorRequired(BrightwheelError):
+    """Login succeeded but a 2FA code is needed before issuing a session."""
+
+
+@dataclass
+class BrightwheelSession:
+    """Persistable session state.
+
+    Stored in the config entry options; carries the cookie jar contents
+    plus the CSRF token. Cookies are stored as a list of (name, value,
+    domain, path) tuples so that the cookie jar can be rebuilt across
+    Home Assistant restarts.
+    """
+
+    csrf_token: str = ""
+    cookies: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"csrf_token": self.csrf_token, "cookies": self.cookies}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "BrightwheelSession":
+        if not isinstance(data, dict):
+            return cls()
+        cookies = data.get("cookies") or []
+        if not isinstance(cookies, list):
+            cookies = []
+        return cls(
+            csrf_token=str(data.get("csrf_token") or ""),
+            cookies=[c for c in cookies if isinstance(c, dict)],
+        )
+
+
+def _default_headers(csrf_token: str | None = None) -> dict[str, str]:
+    headers = {
+        "accept": "application/json",
+        "content-type": "application/json",
+        "x-client-name": BRIGHTWHEEL_CLIENT_NAME,
+        "x-client-version": BRIGHTWHEEL_CLIENT_VERSION,
+        "origin": BRIGHTWHEEL_BASE,
+        "referer": f"{BRIGHTWHEEL_BASE}/",
+    }
+    if csrf_token:
+        headers["x-csrf-token"] = csrf_token
+    return headers
+
+
+def _serialise_cookies(jar: aiohttp.CookieJar | Any) -> list[dict[str, str]]:
+    """Pull cookies out of an aiohttp jar into a JSON-serialisable list."""
+    out: list[dict[str, str]] = []
+    try:
+        for cookie in jar:  # type: ignore[assignment]
+            out.append({
+                "name": cookie.key,
+                "value": cookie.value,
+                "domain": cookie.get("domain") or "",
+                "path": cookie.get("path") or "/",
+            })
+    except Exception as err:  # pragma: no cover - defensive
+        _LOGGER.debug("Brightwheel: cookie serialise failed: %s", err)
+    return out
+
+
+def _restore_cookies(jar: aiohttp.CookieJar, cookies: list[dict[str, str]]) -> None:
+    """Restore previously-serialised cookies into a jar."""
+    if not cookies:
+        return
+    from yarl import URL
+
+    by_url: dict[str, dict[str, str]] = {}
+    for c in cookies:
+        name = c.get("name")
+        value = c.get("value")
+        if not name or value is None:
+            continue
+        domain = (c.get("domain") or "").lstrip(".") or "schools.mybrightwheel.com"
+        path = c.get("path") or "/"
+        url = URL(f"https://{domain}{path}")
+        by_url.setdefault(str(url), {})[name] = value
+
+    for url_str, name_value in by_url.items():
+        try:
+            jar.update_cookies(name_value, response_url=URL(url_str))
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("Brightwheel: cookie restore failed for %s: %s", url_str, err)
+
+
+async def _fetch_csrf(session: aiohttp.ClientSession) -> str:
+    """Hit /api/sessions/start to obtain a fresh CSRF token + cookie."""
+    url = f"{BRIGHTWHEEL_BASE}/api/sessions/start"
+    async with async_timeout.timeout(_LOGIN_TIMEOUT):
+        async with session.get(url, headers=_default_headers()) as resp:
+            if resp.status >= 400:
+                raise BrightwheelError(f"CSRF bootstrap failed: HTTP {resp.status}")
+            try:
+                payload = await resp.json(content_type=None)
+            except Exception:
+                payload = {}
+
+    token = ""
+    if isinstance(payload, dict):
+        token = (
+            payload.get("csrf")
+            or payload.get("csrf_token")
+            or payload.get("authenticity_token")
+            or ""
+        )
+    if not token:
+        # Fall back to the cookie value Brightwheel sets on the bootstrap.
+        for cookie_name in ("csrf-token", "_brightwheel_csrf"):
+            cookie = session.cookie_jar.filter_cookies(BRIGHTWHEEL_BASE).get(cookie_name)
+            if cookie:
+                token = cookie.value
+                break
+    if not token:
+        raise BrightwheelError("Brightwheel did not return a CSRF token")
+    return token
+
+
+async def login(
+    session: aiohttp.ClientSession,
+    email: str,
+    password: str,
+    *,
+    code: str | None = None,
+) -> BrightwheelSession:
+    """Authenticate against Brightwheel.
+
+    Raises :class:`BrightwheelTwoFactorRequired` after the first call when
+    a code is needed; the caller should prompt the user and call again
+    with ``code`` set.
+    """
+    csrf_token = await _fetch_csrf(session)
+
+    if code:
+        # Final step: include the 2FA code.
+        url = f"{BRIGHTWHEEL_BASE}/api/v1/sessions"
+        body = {
+            "user": {"email": email, "password": password, "2fa_code": code},
+        }
+    else:
+        # First step: validate creds, may trigger a 2FA email.
+        url = f"{BRIGHTWHEEL_BASE}/api/v1/sessions/start"
+        body = {"user": {"email": email, "password": password}}
+
+    async with async_timeout.timeout(_LOGIN_TIMEOUT):
+        async with session.post(url, json=body, headers=_default_headers(csrf_token)) as resp:
+            status = resp.status
+            try:
+                payload = await resp.json(content_type=None)
+            except Exception:
+                payload = {}
+
+    if status in (401, 403):
+        raise BrightwheelAuthRequired(
+            f"Brightwheel rejected credentials (HTTP {status})"
+        )
+    if status >= 400:
+        raise BrightwheelError(f"Brightwheel login failed: HTTP {status}")
+
+    if isinstance(payload, dict) and payload.get("2fa_code_required"):
+        # No session cookie yet - bubble up so the config flow can prompt.
+        raise BrightwheelTwoFactorRequired(
+            "Brightwheel emailed a 6-digit verification code"
+        )
+
+    # Success: return the cookie jar + csrf for persistence.
+    return BrightwheelSession(
+        csrf_token=csrf_token,
+        cookies=_serialise_cookies(session.cookie_jar),
+    )
+
+
+async def _get_json(
+    session: aiohttp.ClientSession,
+    url: str,
+    csrf_token: str,
+) -> Any:
+    async with async_timeout.timeout(_FETCH_TIMEOUT):
+        async with session.get(url, headers=_default_headers(csrf_token)) as resp:
+            if resp.status in (401, 403):
+                raise BrightwheelAuthRequired(
+                    f"Brightwheel session expired (HTTP {resp.status})"
+                )
+            if resp.status >= 400:
+                raise BrightwheelError(
+                    f"Brightwheel API error {resp.status} on {url}"
+                )
+            return await resp.json(content_type=None)
+
+
+async def fetch_guardian_id(
+    session: aiohttp.ClientSession,
+    csrf_token: str,
+) -> str:
+    payload = await _get_json(
+        session, f"{BRIGHTWHEEL_BASE}/api/v1/users/me", csrf_token
+    )
+    if not isinstance(payload, dict):
+        raise BrightwheelError("Unexpected /users/me response shape")
+    # Brightwheel nests the guardian under "object_id" or "id" depending on
+    # the deployment; try both.
+    obj_id = payload.get("object_id") or payload.get("id")
+    user = payload.get("user") if isinstance(payload.get("user"), dict) else None
+    if not obj_id and user:
+        obj_id = user.get("object_id") or user.get("id")
+    if not isinstance(obj_id, str) or not obj_id:
+        raise BrightwheelError("Could not determine Brightwheel guardian id")
+    return obj_id
+
+
+async def fetch_students(
+    session: aiohttp.ClientSession,
+    csrf_token: str,
+    guardian_id: str,
+) -> list[dict[str, Any]]:
+    """Return [{id, name}, ...] for all students linked to the guardian."""
+    url = f"{BRIGHTWHEEL_BASE}/api/v1/guardians/{quote(guardian_id, safe='')}/students"
+    payload = await _get_json(session, url, csrf_token)
+
+    students_raw: list[Any] = []
+    if isinstance(payload, list):
+        students_raw = payload
+    elif isinstance(payload, dict):
+        for key in ("students", "data", "results"):
+            v = payload.get(key)
+            if isinstance(v, list):
+                students_raw = v
+                break
+
+    out: list[dict[str, Any]] = []
+    for raw in students_raw:
+        if not isinstance(raw, dict):
+            continue
+        sid = raw.get("object_id") or raw.get("id")
+        if not isinstance(sid, str) or not sid:
+            continue
+        first = raw.get("first_name") or ""
+        last = raw.get("last_name") or ""
+        name = (first + " " + last).strip() or raw.get("name") or sid
+        out.append({"id": sid, "name": name})
+    return out
+
+
+def _parse_iso_to_ms(value: Any) -> int | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        iso = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def _parse_activity(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Normalise a Brightwheel activity into a media-item dict.
+
+    Returns ``None`` for activities that aren't photo/video, lack a usable
+    URL, or are explicitly videos (we skip videos like Google Photos).
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    action_type = raw.get("action_type") or raw.get("type") or ""
+    if isinstance(action_type, str) and action_type.startswith("ac_video"):
+        return None
+
+    media = raw.get("media") if isinstance(raw.get("media"), dict) else raw
+    image_url = (
+        media.get("image_url")
+        or media.get("url")
+        or raw.get("image_url")
+    )
+    if not isinstance(image_url, str) or not image_url.startswith("http"):
+        return None
+
+    if media.get("video_url") or raw.get("video_url"):
+        # Photo+video combos - keep the still image only.
+        pass
+
+    captured_at = _parse_iso_to_ms(
+        raw.get("event_date")
+        or raw.get("created_at")
+        or media.get("created_at")
+    )
+    uploaded_at = _parse_iso_to_ms(raw.get("created_at") or media.get("created_at"))
+
+    activity_id = raw.get("object_id") or raw.get("id")
+    filename = None
+    if isinstance(activity_id, str):
+        filename = f"brightwheel_{activity_id}.jpg"
+
+    return {
+        "url": image_url,
+        "width": _safe_int(media.get("width")) or _safe_int(raw.get("image_width")),
+        "height": _safe_int(media.get("height")) or _safe_int(raw.get("image_height")),
+        "mime_type": "image/jpeg",
+        "filename": filename,
+        "captured_at": captured_at,
+        "uploaded_at": uploaded_at,
+        "byte_size": _safe_int(media.get("file_size")) or _safe_int(raw.get("file_size")),
+    }
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def fetch_activities(
+    session: aiohttp.ClientSession,
+    csrf_token: str,
+    student_id: str,
+    *,
+    page_size: int = BRIGHTWHEEL_DEFAULT_PAGE_SIZE,
+    max_pages: int = 200,
+    earliest_event_date: str | None = None,
+) -> list[dict[str, Any]]:
+    """Walk a student's photo activities; returns raw activity dicts."""
+    activities: list[dict[str, Any]] = []
+    page = 0
+    while page < max_pages:
+        params = [
+            ("page", str(page)),
+            ("page_size", str(page_size)),
+            ("action_type", "ac_photo"),
+        ]
+        if earliest_event_date:
+            params.append(("earliest_event_date", earliest_event_date))
+        query = "&".join(f"{k}={quote(v, safe='')}" for k, v in params)
+        url = (
+            f"{BRIGHTWHEEL_BASE}/api/v1/students/{quote(student_id, safe='')}"
+            f"/activities?{query}"
+        )
+
+        payload = await _get_json(session, url, csrf_token)
+
+        page_items: list[Any] = []
+        if isinstance(payload, list):
+            page_items = payload
+        elif isinstance(payload, dict):
+            for key in ("activities", "data", "results"):
+                v = payload.get(key)
+                if isinstance(v, list):
+                    page_items = v
+                    break
+
+        if not page_items:
+            break
+
+        activities.extend([it for it in page_items if isinstance(it, dict)])
+
+        # Brightwheel returns full pages until it runs out; stop when we
+        # see a partial page.
+        if len(page_items) < page_size:
+            break
+        page += 1
+
+    return activities
+
+
+async def fetch_album(
+    session: aiohttp.ClientSession,
+    bw_session: BrightwheelSession,
+    *,
+    student_ids: list[str] | None = None,
+    earliest_event_date: str | None = None,
+) -> tuple[str | None, list[dict[str, Any]], BrightwheelSession]:
+    """Top-level entry point used by the coordinator.
+
+    Returns ``(album_title, items, refreshed_session)`` where ``items`` is
+    a list of dicts compatible with :class:`coordinator.MediaItem`. The
+    session is returned because the cookie jar may have been rotated.
+    """
+    if not bw_session.csrf_token or not bw_session.cookies:
+        raise BrightwheelAuthRequired("Brightwheel session not initialised")
+
+    _restore_cookies(session.cookie_jar, bw_session.cookies)
+    csrf = bw_session.csrf_token
+
+    guardian_id = await fetch_guardian_id(session, csrf)
+    students = await fetch_students(session, csrf, guardian_id)
+    if not students:
+        raise BrightwheelError("Brightwheel returned no students for this guardian")
+
+    if student_ids:
+        wanted = set(student_ids)
+        students = [s for s in students if s["id"] in wanted]
+        if not students:
+            raise BrightwheelError("None of the configured student ids were found")
+
+    items: list[dict[str, Any]] = []
+    seen_urls: set[str] = set()
+    for student in students:
+        raw_activities = await fetch_activities(
+            session,
+            csrf,
+            student["id"],
+            earliest_event_date=earliest_event_date,
+        )
+        for raw in raw_activities:
+            parsed = _parse_activity(raw)
+            if not parsed:
+                continue
+            if parsed["url"] in seen_urls:
+                continue
+            seen_urls.add(parsed["url"])
+            items.append(parsed)
+
+    title = ", ".join(s["name"] for s in students) or None
+
+    refreshed = BrightwheelSession(
+        csrf_token=csrf,
+        cookies=_serialise_cookies(session.cookie_jar),
+    )
+    return title, items, refreshed

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -1,23 +1,35 @@
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
-    DOMAIN,
-    CONF_PROVIDER,
     CONF_ALBUM_NAME,
     CONF_ALBUM_URL,
+    CONF_BRIGHTWHEEL_2FA_CODE,
+    CONF_BRIGHTWHEEL_EMAIL,
+    CONF_BRIGHTWHEEL_LOOKBACK_DAYS,
+    CONF_BRIGHTWHEEL_PASSWORD,
+    CONF_BRIGHTWHEEL_SESSION,
+    CONF_BRIGHTWHEEL_STUDENT_IDS,
     CONF_LOCAL_PATH,
+    CONF_PROVIDER,
     CONF_RECURSIVE,
+    DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS,
+    DEFAULT_RECURSIVE,
+    DOMAIN,
+    PROVIDER_BRIGHTWHEEL,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
-    DEFAULT_RECURSIVE,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _normalize_local_path(hass, path: str) -> str:
@@ -49,20 +61,32 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         self._provider: str | None = None
+        self._bw_email: str | None = None
+        self._bw_password: str | None = None
+        self._bw_album_name: str | None = None
+        self._bw_lookback_days: int = DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS
+        self._bw_students: list[dict[str, Any]] = []
+        self._bw_session_dict: dict[str, Any] | None = None
+        self._reauth_entry: config_entries.ConfigEntry | None = None
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
             self._provider = user_input[CONF_PROVIDER]
             if self._provider == PROVIDER_LOCAL_FOLDER:
                 return await self.async_step_local_folder()
+            if self._provider == PROVIDER_BRIGHTWHEEL:
+                return await self.async_step_brightwheel_credentials()
             return await self.async_step_google_shared()
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_PROVIDER, default=PROVIDER_GOOGLE_SHARED): vol.In({
-                    PROVIDER_GOOGLE_SHARED: "Google Photos",
-                    PROVIDER_LOCAL_FOLDER: "Local Folder",
-                })
+                vol.Required(CONF_PROVIDER, default=PROVIDER_GOOGLE_SHARED): vol.In(
+                    {
+                        PROVIDER_GOOGLE_SHARED: "Google Photos",
+                        PROVIDER_LOCAL_FOLDER: "Local Folder",
+                        PROVIDER_BRIGHTWHEEL: "Brightwheel",
+                    }
+                )
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema)
@@ -127,3 +151,209 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="local_folder", data_schema=schema, errors=errors)
+
+    # --------------------------- Brightwheel ---------------------------
+
+    async def async_step_brightwheel_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        from . import brightwheel_scraper as bw
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            email = (user_input.get(CONF_BRIGHTWHEEL_EMAIL) or "").strip()
+            password = user_input.get(CONF_BRIGHTWHEEL_PASSWORD) or ""
+            album_name = (user_input.get(CONF_ALBUM_NAME) or "").strip()
+            lookback_days = int(
+                user_input.get(
+                    CONF_BRIGHTWHEEL_LOOKBACK_DAYS, DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS
+                )
+            )
+
+            if not email or "@" not in email:
+                errors[CONF_BRIGHTWHEEL_EMAIL] = "invalid_email"
+            elif not password:
+                errors[CONF_BRIGHTWHEEL_PASSWORD] = "invalid_password"
+            elif not album_name and self._reauth_entry is None:
+                errors[CONF_ALBUM_NAME] = "invalid_album_name"
+            else:
+                self._bw_email = email
+                self._bw_password = password
+                self._bw_album_name = album_name or (
+                    self._reauth_entry.title if self._reauth_entry else "Brightwheel"
+                )
+                self._bw_lookback_days = max(0, lookback_days)
+
+                session = async_get_clientsession(self.hass)
+                try:
+                    await bw.login(session, email, password)
+                except bw.BrightwheelTwoFactorRequired:
+                    return await self.async_step_brightwheel_2fa()
+                except bw.BrightwheelAuthRequired:
+                    errors["base"] = "invalid_auth"
+                except bw.BrightwheelError as err:
+                    _LOGGER.warning("Brightwheel login error: %s", err)
+                    errors["base"] = "cannot_connect"
+                except Exception as err:  # pragma: no cover - defensive
+                    _LOGGER.exception("Brightwheel login unexpected error: %s", err)
+                    errors["base"] = "unknown"
+
+        default_email = self._bw_email or ""
+        schema_dict: dict[Any, Any] = {
+            vol.Required(CONF_BRIGHTWHEEL_EMAIL, default=default_email): str,
+            vol.Required(CONF_BRIGHTWHEEL_PASSWORD): str,
+        }
+        if self._reauth_entry is None:
+            schema_dict[
+                vol.Required(CONF_ALBUM_NAME, default=self._bw_album_name or "")
+            ] = str
+            schema_dict[
+                vol.Optional(
+                    CONF_BRIGHTWHEEL_LOOKBACK_DAYS,
+                    default=DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS,
+                )
+            ] = vol.All(vol.Coerce(int), vol.Range(min=0, max=3650))
+
+        return self.async_show_form(
+            step_id="brightwheel_credentials",
+            data_schema=vol.Schema(schema_dict),
+            errors=errors,
+        )
+
+    async def async_step_brightwheel_2fa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        from . import brightwheel_scraper as bw
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            code = (user_input.get(CONF_BRIGHTWHEEL_2FA_CODE) or "").strip()
+            if not re.fullmatch(r"\d{4,8}", code):
+                errors[CONF_BRIGHTWHEEL_2FA_CODE] = "invalid_code"
+            else:
+                session = async_get_clientsession(self.hass)
+                try:
+                    bw_session = await bw.login(
+                        session,
+                        self._bw_email or "",
+                        self._bw_password or "",
+                        code=code,
+                    )
+                except bw.BrightwheelTwoFactorRequired:
+                    errors["base"] = "two_factor_required"
+                except bw.BrightwheelAuthRequired:
+                    errors["base"] = "invalid_code"
+                except bw.BrightwheelError as err:
+                    _LOGGER.warning("Brightwheel 2FA verification failed: %s", err)
+                    errors["base"] = "cannot_connect"
+                else:
+                    self._bw_session_dict = bw_session.to_dict()
+                    if self._reauth_entry is not None:
+                        return await self._async_finish_reauth()
+                    try:
+                        guardian_id = await bw.fetch_guardian_id(
+                            session, bw_session.csrf_token
+                        )
+                        students = await bw.fetch_students(
+                            session, bw_session.csrf_token, guardian_id
+                        )
+                    except bw.BrightwheelError as err:
+                        _LOGGER.warning("Brightwheel student lookup failed: %s", err)
+                        errors["base"] = "cannot_connect"
+                    else:
+                        if not students:
+                            errors["base"] = "no_students"
+                        else:
+                            self._bw_students = students
+                            return await self.async_step_brightwheel_students()
+
+        return self.async_show_form(
+            step_id="brightwheel_2fa",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_BRIGHTWHEEL_2FA_CODE): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_brightwheel_students(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+        student_options = {s["id"]: s["name"] for s in self._bw_students}
+        all_ids = list(student_options.keys())
+
+        if user_input is not None:
+            picked_raw = user_input.get(CONF_BRIGHTWHEEL_STUDENT_IDS) or all_ids
+            if isinstance(picked_raw, str):
+                picked: list[str] = [picked_raw]
+            else:
+                picked = list(picked_raw)
+
+            if not picked:
+                errors[CONF_BRIGHTWHEEL_STUDENT_IDS] = "no_students_selected"
+            else:
+                await self.async_set_unique_id(
+                    f"{DOMAIN}:{PROVIDER_BRIGHTWHEEL}:{(self._bw_email or '').lower()}"
+                )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=self._bw_album_name or "Brightwheel",
+                    data={
+                        CONF_PROVIDER: PROVIDER_BRIGHTWHEEL,
+                        CONF_ALBUM_NAME: self._bw_album_name or "Brightwheel",
+                        CONF_BRIGHTWHEEL_EMAIL: self._bw_email,
+                        CONF_BRIGHTWHEEL_PASSWORD: self._bw_password,
+                        CONF_BRIGHTWHEEL_SESSION: self._bw_session_dict,
+                        CONF_BRIGHTWHEEL_STUDENT_IDS: picked,
+                        CONF_BRIGHTWHEEL_LOOKBACK_DAYS: self._bw_lookback_days,
+                    },
+                )
+
+        # HA's frontend renders ``vol.In(dict)`` as a single-select; for
+        # multi-select we fall back to the loose schema below and let the
+        # frontend show checkboxes via the ``multi_select`` translation.
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_BRIGHTWHEEL_STUDENT_IDS, default=all_ids
+                ): [vol.In(student_options)],
+            }
+        )
+        return self.async_show_form(
+            step_id="brightwheel_students",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"count": str(len(student_options))},
+        )
+
+    # ----------------------------- Reauth -----------------------------
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if self._reauth_entry is None:
+            return self.async_abort(reason="reauth_unknown")
+
+        self._provider = self._reauth_entry.data.get(CONF_PROVIDER)
+        if self._provider != PROVIDER_BRIGHTWHEEL:
+            return self.async_abort(reason="reauth_not_supported")
+
+        self._bw_email = self._reauth_entry.data.get(CONF_BRIGHTWHEEL_EMAIL)
+        self._bw_album_name = self._reauth_entry.title
+        return await self.async_step_brightwheel_credentials()
+
+    async def _async_finish_reauth(self) -> FlowResult:
+        if self._reauth_entry is None:
+            return self.async_abort(reason="reauth_unknown")
+
+        new_data = dict(self._reauth_entry.data)
+        new_data[CONF_BRIGHTWHEEL_EMAIL] = self._bw_email
+        new_data[CONF_BRIGHTWHEEL_PASSWORD] = self._bw_password
+        new_data[CONF_BRIGHTWHEEL_SESSION] = self._bw_session_dict
+
+        self.hass.config_entries.async_update_entry(self._reauth_entry, data=new_data)
+        await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+        return self.async_abort(reason="reauth_successful")

--- a/custom_components/album_slideshow/const.py
+++ b/custom_components/album_slideshow/const.py
@@ -7,8 +7,18 @@ CONF_LOCAL_PATH = "local_path"
 CONF_RECURSIVE = "recursive"
 CONF_IMAGE_CACHE_MB = "image_cache_mb"
 
+# Brightwheel
+CONF_BRIGHTWHEEL_EMAIL = "brightwheel_email"
+CONF_BRIGHTWHEEL_PASSWORD = "brightwheel_password"
+CONF_BRIGHTWHEEL_2FA_CODE = "brightwheel_2fa_code"
+CONF_BRIGHTWHEEL_SESSION = "brightwheel_session"
+CONF_BRIGHTWHEEL_STUDENT_IDS = "brightwheel_student_ids"
+CONF_BRIGHTWHEEL_LOOKBACK_DAYS = "brightwheel_lookback_days"
+DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS = 365
+
 PROVIDER_GOOGLE_SHARED = "google_shared"
 PROVIDER_LOCAL_FOLDER = "local_folder"
+PROVIDER_BRIGHTWHEEL = "brightwheel"
 
 FILL_COVER = "cover"
 FILL_CONTAIN = "contain"
@@ -76,6 +86,10 @@ MAX_RESOLUTION_SHORT_EDGE: dict[str, int | None] = {
 }
 
 PUBLICALBUM_ENDPOINT = "https://www.publicalbum.org/api/v2/webapp/embed-player/jsonrpc"
+BRIGHTWHEEL_BASE = "https://schools.mybrightwheel.com"
+BRIGHTWHEEL_CLIENT_NAME = "web"
+BRIGHTWHEEL_CLIENT_VERSION = "234"
+BRIGHTWHEEL_DEFAULT_PAGE_SIZE = 50
 
 SERVICE_NEXT_SLIDE = "next_slide"
 SERVICE_REFRESH_ALBUM = "refresh_album"

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .const import (
     PUBLICALBUM_ENDPOINT,
@@ -20,7 +21,14 @@ from .const import (
     CONF_ALBUM_URL,
     CONF_LOCAL_PATH,
     CONF_RECURSIVE,
+    CONF_BRIGHTWHEEL_EMAIL,
+    CONF_BRIGHTWHEEL_PASSWORD,
+    CONF_BRIGHTWHEEL_SESSION,
+    CONF_BRIGHTWHEEL_STUDENT_IDS,
+    CONF_BRIGHTWHEEL_LOOKBACK_DAYS,
+    DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS,
     DOMAIN,
+    PROVIDER_BRIGHTWHEEL,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
 )
@@ -247,8 +255,14 @@ class AlbumCoordinator(DataUpdateCoordinator):
                 data = await self._update_local_folder()
             elif self.provider == PROVIDER_GOOGLE_SHARED:
                 data = await self._update_google_shared()
+            elif self.provider == PROVIDER_BRIGHTWHEEL:
+                data = await self._update_brightwheel()
             else:
                 raise UpdateFailed(f"Unsupported provider: {self.provider}")
+        except ConfigEntryAuthFailed:
+            # Surfaces in HA as a Reauth notification - never fall back to
+            # the cache, the user needs to take action.
+            raise
         except UpdateFailed:
             cached = await self._load_cached_items()
             if cached and cached.get("items"):
@@ -586,4 +600,101 @@ class AlbumCoordinator(DataUpdateCoordinator):
         return {
             "title": result.get("title") or self.entry.title,
             "items": api_items,
+        }
+
+
+    async def _update_brightwheel(self) -> dict[str, Any]:
+        """Fetch photos from the configured Brightwheel guardian account."""
+        from . import brightwheel_scraper as bw
+
+        data = self.entry.data
+        email = data.get(CONF_BRIGHTWHEEL_EMAIL)
+        password = data.get(CONF_BRIGHTWHEEL_PASSWORD)
+        session_dict = data.get(CONF_BRIGHTWHEEL_SESSION)
+        student_ids = data.get(CONF_BRIGHTWHEEL_STUDENT_IDS) or []
+        lookback_days = int(
+            data.get(CONF_BRIGHTWHEEL_LOOKBACK_DAYS, DEFAULT_BRIGHTWHEEL_LOOKBACK_DAYS)
+        )
+
+        if not email or not password:
+            raise ConfigEntryAuthFailed("Brightwheel credentials missing")
+        bw_session = bw.BrightwheelSession.from_dict(session_dict)
+        if not bw_session.csrf_token or not bw_session.cookies:
+            raise ConfigEntryAuthFailed("Brightwheel session not initialised")
+
+        earliest = None
+        if lookback_days > 0:
+            from datetime import datetime, timedelta, timezone
+
+            earliest_dt = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+            earliest = earliest_dt.date().isoformat()
+
+        http_session = async_get_clientsession(self.hass)
+
+        # First attempt: use the cached cookie jar.
+        try:
+            title, raw_items, refreshed = await bw.fetch_album(
+                http_session,
+                bw_session,
+                student_ids=student_ids,
+                earliest_event_date=earliest,
+            )
+        except bw.BrightwheelAuthRequired:
+            # Try a silent re-login with stored credentials before bothering
+            # the user. This handles the common "session cookie expired"
+            # case without a Repair card.
+            _LOGGER.info("Brightwheel: session expired, attempting silent re-login")
+            try:
+                bw_session = await bw.login(http_session, email, password)
+            except bw.BrightwheelTwoFactorRequired:
+                raise ConfigEntryAuthFailed(
+                    "Brightwheel needs a new 2FA code"
+                ) from None
+            except (bw.BrightwheelAuthRequired, bw.BrightwheelError) as err:
+                raise ConfigEntryAuthFailed(str(err)) from err
+
+            try:
+                title, raw_items, refreshed = await bw.fetch_album(
+                    http_session,
+                    bw_session,
+                    student_ids=student_ids,
+                    earliest_event_date=earliest,
+                )
+            except bw.BrightwheelAuthRequired as err:
+                raise ConfigEntryAuthFailed(str(err)) from err
+            except bw.BrightwheelError as err:
+                raise UpdateFailed(f"Brightwheel API error: {err}") from err
+        except bw.BrightwheelError as err:
+            raise UpdateFailed(f"Brightwheel API error: {err}") from err
+
+        # Persist the (possibly rotated) cookie jar back onto the entry.
+        if refreshed.cookies and refreshed.cookies != bw_session.cookies:
+            new_data = dict(self.entry.data)
+            new_data[CONF_BRIGHTWHEEL_SESSION] = refreshed.to_dict()
+            self.hass.config_entries.async_update_entry(self.entry, data=new_data)
+
+        items: list[MediaItem] = [
+            MediaItem(
+                url=raw["url"],
+                width=raw.get("width"),
+                height=raw.get("height"),
+                mime_type=raw.get("mime_type"),
+                filename=raw.get("filename"),
+                captured_at=raw.get("captured_at"),
+                uploaded_at=raw.get("uploaded_at"),
+                byte_size=raw.get("byte_size"),
+            )
+            for raw in raw_items
+            if raw.get("url")
+        ]
+
+        _LOGGER.info(
+            "Album scraper: source=brightwheel items=%d (students=%d)",
+            len(items),
+            len(student_ids) if student_ids else 0,
+        )
+
+        return {
+            "title": title or self.entry.title,
+            "items": items,
         }

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/album_slideshow/strings.json
+++ b/custom_components/album_slideshow/strings.json
@@ -24,11 +24,50 @@
           "local_path": "Folder path",
           "recursive": "Include subfolders"
         }
+      },
+      "brightwheel_credentials": {
+        "title": "Brightwheel",
+        "description": "Sign in to your Brightwheel guardian account. The integration uses the same private API as the Brightwheel app; only photos shared with you are accessed. A 2FA code may be emailed to you on the next step.",
+        "data": {
+          "brightwheel_email": "Email",
+          "brightwheel_password": "Password",
+          "album_name": "Album name",
+          "brightwheel_lookback_days": "Lookback (days, 0 = all)"
+        }
+      },
+      "brightwheel_2fa": {
+        "title": "Brightwheel 2FA",
+        "description": "Brightwheel just emailed you a verification code. Enter it below.",
+        "data": {
+          "brightwheel_2fa_code": "6-digit code"
+        }
+      },
+      "brightwheel_students": {
+        "title": "Brightwheel students",
+        "description": "Found {count} student(s). Pick which ones to include in the slideshow (leave all selected for everyone).",
+        "data": {
+          "brightwheel_student_ids": "Students"
+        }
       }
     },
     "error": {
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
-      "invalid_path": "Path is empty or invalid."
+      "invalid_path": "Path is empty or invalid.",
+      "invalid_email": "Enter a valid email address.",
+      "invalid_password": "Password is required.",
+      "invalid_album_name": "Give the album a name.",
+      "invalid_code": "Code must be 4-8 digits.",
+      "invalid_auth": "Brightwheel rejected those credentials.",
+      "two_factor_required": "Brightwheel still expects a 2FA code.",
+      "no_students": "No students found on this Brightwheel account.",
+      "no_students_selected": "Select at least one student.",
+      "cannot_connect": "Could not reach Brightwheel.",
+      "unknown": "Something went wrong. Check the Home Assistant log."
+    },
+    "abort": {
+      "reauth_unknown": "Could not find the Brightwheel entry to re-authenticate.",
+      "reauth_not_supported": "Re-authentication is only supported for the Brightwheel provider.",
+      "reauth_successful": "Brightwheel re-authentication completed."
     }
   }
 }

--- a/custom_components/album_slideshow/translations/en.json
+++ b/custom_components/album_slideshow/translations/en.json
@@ -24,11 +24,50 @@
           "local_path": "Folder path",
           "recursive": "Include subfolders"
         }
+      },
+      "brightwheel_credentials": {
+        "title": "Brightwheel",
+        "description": "Sign in to your Brightwheel guardian account. The integration uses the same private API as the Brightwheel app; only photos shared with you are accessed. A 2FA code may be emailed to you on the next step.",
+        "data": {
+          "brightwheel_email": "Email",
+          "brightwheel_password": "Password",
+          "album_name": "Album name",
+          "brightwheel_lookback_days": "Lookback (days, 0 = all)"
+        }
+      },
+      "brightwheel_2fa": {
+        "title": "Brightwheel 2FA",
+        "description": "Brightwheel just emailed you a verification code. Enter it below.",
+        "data": {
+          "brightwheel_2fa_code": "6-digit code"
+        }
+      },
+      "brightwheel_students": {
+        "title": "Brightwheel students",
+        "description": "Found {count} student(s). Pick which ones to include in the slideshow (leave all selected for everyone).",
+        "data": {
+          "brightwheel_student_ids": "Students"
+        }
       }
     },
     "error": {
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
-      "invalid_path": "Path is empty or invalid."
+      "invalid_path": "Path is empty or invalid.",
+      "invalid_email": "Enter a valid email address.",
+      "invalid_password": "Password is required.",
+      "invalid_album_name": "Give the album a name.",
+      "invalid_code": "Code must be 4-8 digits.",
+      "invalid_auth": "Brightwheel rejected those credentials.",
+      "two_factor_required": "Brightwheel still expects a 2FA code.",
+      "no_students": "No students found on this Brightwheel account.",
+      "no_students_selected": "Select at least one student.",
+      "cannot_connect": "Could not reach Brightwheel.",
+      "unknown": "Something went wrong. Check the Home Assistant log."
+    },
+    "abort": {
+      "reauth_unknown": "Could not find the Brightwheel entry to re-authenticate.",
+      "reauth_not_supported": "Re-authentication is only supported for the Brightwheel provider.",
+      "reauth_successful": "Brightwheel re-authentication completed."
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ _make_stub(
     "homeassistant.components.camera",
     "homeassistant.config_entries",
     "homeassistant.core",
+    "homeassistant.exceptions",
     "homeassistant.helpers",
     "homeassistant.helpers.aiohttp_client",
     "homeassistant.helpers.entity_platform",
@@ -81,3 +82,32 @@ class _Store:
 
 
 _storage.Store = _Store  # type: ignore[attr-defined]
+
+
+# async_timeout is stubbed above as an empty module; provide a no-op
+# ``timeout`` context manager so coroutines that wrap requests in
+# ``async with async_timeout.timeout(...)`` can run during tests.
+import async_timeout as _async_timeout
+
+
+class _NoopTimeout:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+_async_timeout.timeout = lambda *a, **kw: _NoopTimeout()  # type: ignore[attr-defined]
+
+import homeassistant.exceptions as _exc
+
+
+class _ConfigEntryAuthFailed(Exception):
+    pass
+
+
+_exc.ConfigEntryAuthFailed = _ConfigEntryAuthFailed  # type: ignore[attr-defined]

--- a/tests/test_brightwheel_scraper.py
+++ b/tests/test_brightwheel_scraper.py
@@ -1,0 +1,483 @@
+"""Tests for the Brightwheel scraper.
+
+The integration uses an unofficial REST API; tests mock aiohttp responses
+so we can validate the parsing layer and auth flow without hitting the
+network.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from custom_components.album_slideshow import brightwheel_scraper as bw
+
+
+# ---------------------------------------------------------------------------
+# Tiny async-aiohttp test double.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self, content_type=None):
+        if isinstance(self._payload, str):
+            return json.loads(self._payload)
+        return self._payload
+
+
+class _FakeCookieJar:
+    def __init__(self) -> None:
+        self._cookies: list[dict[str, str]] = []
+
+    def update_cookies(self, cookies: dict[str, str], response_url=None) -> None:
+        for k, v in cookies.items():
+            self._cookies.append(
+                {
+                    "name": k,
+                    "value": v,
+                    "domain": "schools.mybrightwheel.com",
+                    "path": "/",
+                }
+            )
+
+    def filter_cookies(self, url):
+        # Mimic aiohttp's API: returns a Morsel-like dict.
+        class _M:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+        out: dict[str, _M] = {}
+        for c in self._cookies:
+            out[c["name"]] = _M(c["value"])
+        return out
+
+    def __iter__(self):
+        for c in self._cookies:
+            yield _FakeMorsel(c["name"], c["value"], c["domain"], c["path"])
+
+
+class _FakeMorsel:
+    def __init__(self, key: str, value: str, domain: str, path: str) -> None:
+        self.key = key
+        self.value = value
+        self._meta = {"domain": domain, "path": path}
+
+    def get(self, k: str, default=None):
+        return self._meta.get(k, default)
+
+
+class FakeSession:
+    """Records every request and replays scripted responses by URL prefix."""
+
+    def __init__(self) -> None:
+        self.cookie_jar = _FakeCookieJar()
+        # script: dict[(method, url_substring)] = callable(body) -> _FakeResponse
+        self._handlers: dict[tuple[str, str], Any] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def on(self, method: str, url_substring: str, handler) -> None:
+        self._handlers[(method.upper(), url_substring)] = handler
+
+    def _resolve(self, method: str, url: str):
+        for (m, sub), handler in self._handlers.items():
+            if m == method and sub in url:
+                return handler
+        raise AssertionError(f"No handler for {method} {url}")
+
+    def get(self, url, headers=None, **kwargs):
+        self.calls.append({"method": "GET", "url": url, "headers": headers})
+        handler = self._resolve("GET", url)
+        return handler(url, kwargs)
+
+    def post(self, url, json=None, headers=None, **kwargs):
+        self.calls.append(
+            {"method": "POST", "url": url, "headers": headers, "json": json}
+        )
+        handler = self._resolve("POST", url)
+        return handler(url, {"json": json, **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# _parse_activity
+# ---------------------------------------------------------------------------
+
+
+def test_parse_activity_extracts_image_and_timestamps():
+    raw = {
+        "object_id": "act-123",
+        "action_type": "ac_photo",
+        "event_date": "2025-09-12T15:30:00Z",
+        "created_at": "2025-09-12T15:31:00Z",
+        "media": {
+            "image_url": "https://bw-cdn.example/photos/abc.jpg?sig=xyz",
+            "width": 1920,
+            "height": 1280,
+            "file_size": 412300,
+        },
+    }
+    parsed = bw._parse_activity(raw)
+    assert parsed is not None
+    assert parsed["url"].startswith("https://bw-cdn.example/")
+    assert parsed["width"] == 1920 and parsed["height"] == 1280
+    assert parsed["captured_at"] == 1757691000000
+    assert parsed["uploaded_at"] == 1757691060000
+    assert parsed["byte_size"] == 412300
+    assert parsed["filename"] == "brightwheel_act-123.jpg"
+    assert parsed["mime_type"] == "image/jpeg"
+
+
+def test_parse_activity_skips_videos():
+    raw = {
+        "action_type": "ac_video",
+        "media": {"image_url": "https://bw-cdn.example/v/thumb.jpg"},
+    }
+    assert bw._parse_activity(raw) is None
+
+
+def test_parse_activity_handles_missing_url():
+    assert bw._parse_activity({"action_type": "ac_photo", "media": {}}) is None
+
+
+def test_parse_activity_falls_back_to_top_level_url():
+    parsed = bw._parse_activity(
+        {
+            "action_type": "ac_photo",
+            "image_url": "https://bw-cdn.example/p.jpg",
+        }
+    )
+    assert parsed is not None
+    assert parsed["url"] == "https://bw-cdn.example/p.jpg"
+
+
+# ---------------------------------------------------------------------------
+# Cookie persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def test_brightwheel_session_round_trips_cookies():
+    s = bw.BrightwheelSession(
+        csrf_token="abc",
+        cookies=[
+            {"name": "_brightwheel_v2", "value": "x", "domain": "schools.mybrightwheel.com", "path": "/"},
+        ],
+    )
+    again = bw.BrightwheelSession.from_dict(s.to_dict())
+    assert again.csrf_token == "abc"
+    assert again.cookies == s.cookies
+
+
+def test_brightwheel_session_from_dict_handles_garbage():
+    assert bw.BrightwheelSession.from_dict(None).csrf_token == ""
+    assert bw.BrightwheelSession.from_dict({"cookies": "not a list"}).cookies == []
+
+
+# ---------------------------------------------------------------------------
+# Login flow
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def test_login_first_call_raises_two_factor_required(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/sessions/start",
+        lambda url, kw: _FakeResponse(200, {"csrf": "tok-1"}),
+    )
+    session.on(
+        "POST",
+        "/api/v1/sessions/start",
+        lambda url, kw: _FakeResponse(200, {"2fa_code_required": True}),
+    )
+
+    with pytest.raises(bw.BrightwheelTwoFactorRequired):
+        event_loop.run_until_complete(
+            bw.login(session, "guardian@example.com", "hunter2")
+        )
+
+    # Should have hit both endpoints exactly once.
+    methods = [(c["method"], c["url"]) for c in session.calls]
+    assert any("/api/sessions/start" in u for _, u in methods)
+    assert any("/api/v1/sessions/start" in u for _, u in methods)
+
+
+def test_login_with_code_returns_session(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/sessions/start",
+        lambda url, kw: _FakeResponse(200, {"csrf": "tok-2"}),
+    )
+
+    def _post_session(url, kw):
+        # The handler also seeds the session cookie like the real API does.
+        session.cookie_jar.update_cookies({"_brightwheel_v2": "session-cookie"})
+        return _FakeResponse(200, {"user": {"object_id": "guard-1"}})
+
+    session.on("POST", "/api/v1/sessions", _post_session)
+
+    bw_session = event_loop.run_until_complete(
+        bw.login(session, "guardian@example.com", "hunter2", code="123456")
+    )
+    assert bw_session.csrf_token == "tok-2"
+    assert any(c["name"] == "_brightwheel_v2" for c in bw_session.cookies)
+
+
+def test_login_invalid_credentials_raises_auth_required(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/sessions/start",
+        lambda url, kw: _FakeResponse(200, {"csrf": "tok"}),
+    )
+    session.on(
+        "POST",
+        "/api/v1/sessions/start",
+        lambda url, kw: _FakeResponse(401, {"error": "bad credentials"}),
+    )
+    with pytest.raises(bw.BrightwheelAuthRequired):
+        event_loop.run_until_complete(
+            bw.login(session, "guardian@example.com", "wrong")
+        )
+
+
+# ---------------------------------------------------------------------------
+# fetch_album end-to-end (with mocked endpoints)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_album_aggregates_photos_for_all_students(event_loop):
+    session = FakeSession()
+
+    session.on(
+        "GET",
+        "/api/v1/users/me",
+        lambda url, kw: _FakeResponse(200, {"object_id": "guard-1"}),
+    )
+    session.on(
+        "GET",
+        "/api/v1/guardians/guard-1/students",
+        lambda url, kw: _FakeResponse(
+            200,
+            {
+                "students": [
+                    {"object_id": "stu-A", "first_name": "Ada", "last_name": "Lovelace"},
+                    {"object_id": "stu-B", "first_name": "Bob", "last_name": "Builder"},
+                ]
+            },
+        ),
+    )
+
+    page_state: dict[str, int] = {"stu-A": 0, "stu-B": 0}
+
+    def _activities(student_key: str, photos_per_page: int):
+        def _handler(url, kw):
+            page = page_state[student_key]
+            page_state[student_key] = page + 1
+            if page == 0:
+                return _FakeResponse(
+                    200,
+                    {
+                        "activities": [
+                            {
+                                "object_id": f"{student_key}-act-{i}",
+                                "action_type": "ac_photo",
+                                "event_date": "2025-09-01T12:00:00Z",
+                                "media": {
+                                    "image_url": f"https://bw-cdn.example/{student_key}-{i}.jpg"
+                                },
+                            }
+                            for i in range(photos_per_page)
+                        ]
+                    },
+                )
+            return _FakeResponse(200, {"activities": []})
+
+        return _handler
+
+    session.on("GET", "/api/v1/students/stu-A/activities", _activities("stu-A", 3))
+    session.on("GET", "/api/v1/students/stu-B/activities", _activities("stu-B", 2))
+
+    bw_session = bw.BrightwheelSession(
+        csrf_token="tok",
+        cookies=[
+            {
+                "name": "_brightwheel_v2",
+                "value": "x",
+                "domain": "schools.mybrightwheel.com",
+                "path": "/",
+            }
+        ],
+    )
+
+    title, items, refreshed = event_loop.run_until_complete(
+        bw.fetch_album(session, bw_session)
+    )
+
+    assert title == "Ada Lovelace, Bob Builder"
+    assert len(items) == 5
+    # Refreshed session reuses the same csrf and includes restored cookies.
+    assert refreshed.csrf_token == "tok"
+
+
+def test_fetch_album_filters_by_student_ids(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/v1/users/me",
+        lambda url, kw: _FakeResponse(200, {"object_id": "g"}),
+    )
+    session.on(
+        "GET",
+        "/api/v1/guardians/g/students",
+        lambda url, kw: _FakeResponse(
+            200,
+            {
+                "students": [
+                    {"object_id": "stu-A", "first_name": "Ada", "last_name": "L"},
+                    {"object_id": "stu-B", "first_name": "Bob", "last_name": "B"},
+                ]
+            },
+        ),
+    )
+    session.on(
+        "GET",
+        "/api/v1/students/stu-A/activities",
+        lambda url, kw: _FakeResponse(
+            200,
+            {
+                "activities": [
+                    {
+                        "action_type": "ac_photo",
+                        "media": {"image_url": "https://bw-cdn.example/A.jpg"},
+                    }
+                ]
+            },
+        ),
+    )
+
+    bw_session = bw.BrightwheelSession(
+        csrf_token="tok",
+        cookies=[
+            {
+                "name": "_brightwheel_v2",
+                "value": "x",
+                "domain": "schools.mybrightwheel.com",
+                "path": "/",
+            }
+        ],
+    )
+
+    title, items, _ = event_loop.run_until_complete(
+        bw.fetch_album(session, bw_session, student_ids=["stu-A"])
+    )
+    assert title == "Ada L"
+    assert len(items) == 1
+    # Confirm we never hit stu-B's activities endpoint.
+    assert all("stu-B" not in c["url"] for c in session.calls if "/activities" in c["url"])
+
+
+def test_fetch_album_raises_auth_required_on_401(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/v1/users/me",
+        lambda url, kw: _FakeResponse(401, {"error": "expired"}),
+    )
+    bw_session = bw.BrightwheelSession(
+        csrf_token="tok",
+        cookies=[
+            {
+                "name": "_brightwheel_v2",
+                "value": "x",
+                "domain": "schools.mybrightwheel.com",
+                "path": "/",
+            }
+        ],
+    )
+    with pytest.raises(bw.BrightwheelAuthRequired):
+        event_loop.run_until_complete(bw.fetch_album(session, bw_session))
+
+
+def test_fetch_album_requires_initialised_session(event_loop):
+    session = FakeSession()
+    bw_session = bw.BrightwheelSession()
+    with pytest.raises(bw.BrightwheelAuthRequired):
+        event_loop.run_until_complete(bw.fetch_album(session, bw_session))
+
+
+def test_fetch_album_dedupes_urls(event_loop):
+    session = FakeSession()
+    session.on(
+        "GET",
+        "/api/v1/users/me",
+        lambda url, kw: _FakeResponse(200, {"object_id": "g"}),
+    )
+    session.on(
+        "GET",
+        "/api/v1/guardians/g/students",
+        lambda url, kw: _FakeResponse(
+            200,
+            {
+                "students": [
+                    {"object_id": "stu-A", "first_name": "Ada", "last_name": "L"},
+                ]
+            },
+        ),
+    )
+    session.on(
+        "GET",
+        "/api/v1/students/stu-A/activities",
+        lambda url, kw: _FakeResponse(
+            200,
+            {
+                "activities": [
+                    {
+                        "action_type": "ac_photo",
+                        "media": {"image_url": "https://bw-cdn.example/dup.jpg"},
+                    },
+                    {
+                        "action_type": "ac_photo",
+                        "media": {"image_url": "https://bw-cdn.example/dup.jpg"},
+                    },
+                ]
+            },
+        ),
+    )
+    bw_session = bw.BrightwheelSession(
+        csrf_token="tok",
+        cookies=[
+            {
+                "name": "_brightwheel_v2",
+                "value": "x",
+                "domain": "schools.mybrightwheel.com",
+                "path": "/",
+            }
+        ],
+    )
+    _, items, _ = event_loop.run_until_complete(
+        bw.fetch_album(session, bw_session, student_ids=["stu-A"])
+    )
+    assert len(items) == 1

--- a/tests/test_brightwheel_scraper.py
+++ b/tests/test_brightwheel_scraper.py
@@ -36,6 +36,14 @@ class _FakeResponse:
             return json.loads(self._payload)
         return self._payload
 
+    async def text(self):
+        if isinstance(self._payload, str):
+            return self._payload
+        try:
+            return json.dumps(self._payload)
+        except Exception:
+            return ""
+
 
 class _FakeCookieJar:
     def __init__(self) -> None:
@@ -106,6 +114,13 @@ class FakeSession:
             {"method": "POST", "url": url, "headers": headers, "json": json}
         )
         handler = self._resolve("POST", url)
+        return handler(url, {"json": json, **kwargs})
+
+    def request(self, method, url, json=None, headers=None, **kwargs):
+        self.calls.append(
+            {"method": method.upper(), "url": url, "headers": headers, "json": json}
+        )
+        handler = self._resolve(method.upper(), url)
         return handler(url, {"json": json, **kwargs})
 
 
@@ -201,60 +216,57 @@ def event_loop():
 
 def test_login_first_call_raises_two_factor_required(event_loop):
     session = FakeSession()
-    session.on(
-        "GET",
-        "/api/sessions/start",
-        lambda url, kw: _FakeResponse(200, {"csrf": "tok-1"}),
-    )
-    session.on(
-        "POST",
-        "/api/v1/sessions/start",
-        lambda url, kw: _FakeResponse(200, {"2fa_code_required": True}),
-    )
+
+    def _post_session(url, kw):
+        return _FakeResponse(412, {"error": "otp_required"})
+
+    session.on("POST", "/api/v1/sessions", _post_session)
 
     with pytest.raises(bw.BrightwheelTwoFactorRequired):
         event_loop.run_until_complete(
             bw.login(session, "guardian@example.com", "hunter2")
         )
 
-    # Should have hit both endpoints exactly once.
     methods = [(c["method"], c["url"]) for c in session.calls]
-    assert any("/api/sessions/start" in u for _, u in methods)
-    assert any("/api/v1/sessions/start" in u for _, u in methods)
+    assert any(m == "POST" and "/api/v1/sessions" in u for m, u in methods)
+
+
+def test_login_first_call_with_json_flag_raises_two_factor_required(event_loop):
+    session = FakeSession()
+    session.on(
+        "POST",
+        "/api/v1/sessions",
+        lambda url, kw: _FakeResponse(200, {"otp_required": True}),
+    )
+    with pytest.raises(bw.BrightwheelTwoFactorRequired):
+        event_loop.run_until_complete(
+            bw.login(session, "guardian@example.com", "hunter2")
+        )
 
 
 def test_login_with_code_returns_session(event_loop):
     session = FakeSession()
-    session.on(
-        "GET",
-        "/api/sessions/start",
-        lambda url, kw: _FakeResponse(200, {"csrf": "tok-2"}),
-    )
 
-    def _post_session(url, kw):
-        # The handler also seeds the session cookie like the real API does.
-        session.cookie_jar.update_cookies({"_brightwheel_v2": "session-cookie"})
+    def _patch_session(url, kw):
+        session.cookie_jar.update_cookies(
+            {"_brightwheel_v2": "session-cookie", "csrf-token": "rotated-csrf"}
+        )
         return _FakeResponse(200, {"user": {"object_id": "guard-1"}})
 
-    session.on("POST", "/api/v1/sessions", _post_session)
+    session.on("PATCH", "/api/v1/sessions", _patch_session)
 
     bw_session = event_loop.run_until_complete(
         bw.login(session, "guardian@example.com", "hunter2", code="123456")
     )
-    assert bw_session.csrf_token == "tok-2"
+    assert bw_session.csrf_token == "rotated-csrf"
     assert any(c["name"] == "_brightwheel_v2" for c in bw_session.cookies)
 
 
 def test_login_invalid_credentials_raises_auth_required(event_loop):
     session = FakeSession()
     session.on(
-        "GET",
-        "/api/sessions/start",
-        lambda url, kw: _FakeResponse(200, {"csrf": "tok"}),
-    )
-    session.on(
         "POST",
-        "/api/v1/sessions/start",
+        "/api/v1/sessions",
         lambda url, kw: _FakeResponse(401, {"error": "bad credentials"}),
     )
     with pytest.raises(bw.BrightwheelAuthRequired):


### PR DESCRIPTION
Adds **Brightwheel** as a third media provider alongside Google Photos shared albums and local folders. Targets users whose daycare/preschool posts photos via the Brightwheel app.

> ⚠️ Brightwheel does not publish a public API. This integration uses the same private REST endpoints (`schools.mybrightwheel.com/api/v1/...`) as the Brightwheel mobile and web apps. Endpoints have been stable for 3+ years per the broader open-source ecosystem, but no SLA - they could change without notice.

## What works

- Email + password + emailed 6-digit 2FA code login flow
- Session cookies persisted on the config entry, survive HA restarts
- Silent re-login when the cookie expires; HA Repair card / reauth flow when Brightwheel demands a fresh 2FA code
- Per-student multi-select at setup
- Configurable lookback window (default 365 days; 0 = full history)
- Activities mapped to `MediaItem` with `captured_at` (event_date) + `uploaded_at` (created_at), so the 0.6 date filters and order modes work out of the box
- Videos skipped (photos only)

## Tests

101 passed, 14 new for `brightwheel_scraper`. Tests mock the aiohttp layer; live verification still pending.

## Open questions before live testing

- Verify exact endpoint shape for `/api/sessions/start` CSRF response
- Confirm `2fa_code_required` flag name and 2FA submit payload
- Confirm `students/{id}/activities` page-size cap (currently 50)

## Caveats called out in the README

- Photo URLs are short-lived signed S3 links; users on long refresh intervals may see stale images
- Re-auth required every few weeks
- Brightwheel may change endpoints without warning