### PR TITLE
0.7.0: Brightwheel (manual sync) preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ For NAS:
 
 ---
 
+### Brightwheel (manual sync)
+
+Brightwheel cannot be scraped live from Home Assistant: their site is protected by bot detection that rejects plain HTTP clients (which is why every public Brightwheel scraper drives a real browser via undetected-chromedriver).
+
+Workaround: export photos with one of these tools and point the slideshow at the resulting folder.
+
+- Desktop scraper: [`remotephone/brightwheel-crawler`](https://github.com/remotephone/brightwheel-crawler) or its lighter fork [`elitwilliams/brightwheel-image-scraper`](https://github.com/elitwilliams/brightwheel-image-scraper) - run on your PC on a schedule (Windows Task Scheduler / cron).
+- Browser extension: [Picture/Video Downloader](https://chromewebstore.google.com/detail/picture-video-downloader/gljbmiilfgabbipapcmfenedegaklnjb) - log into Brightwheel manually, scroll the feed, download photos in bulk.
+
+Then in Home Assistant:
+
+1. Add the integration and pick **Brightwheel (manual sync)**.
+2. Accept the default folder (`/media/brightwheel`) or change it.
+3. Sync your exported photos into that folder.
+
+The entry is stored as a regular Local Folder source, so any folder-mode features (recursive, ordering, date filters) apply.
+
+---
+
 ## 🧩 Entities Created
 
 Each album you configure creates the following entities in Home Assistant.

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -16,7 +16,9 @@ from .const import (
     CONF_RECURSIVE,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
+    PRESET_BRIGHTWHEEL_MANUAL,
     DEFAULT_RECURSIVE,
+    DEFAULT_BRIGHTWHEEL_PATH,
 )
 
 
@@ -55,6 +57,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._provider = user_input[CONF_PROVIDER]
             if self._provider == PROVIDER_LOCAL_FOLDER:
                 return await self.async_step_local_folder()
+            if self._provider == PRESET_BRIGHTWHEEL_MANUAL:
+                return await self.async_step_brightwheel_manual()
             return await self.async_step_google_shared()
 
         schema = vol.Schema(
@@ -62,6 +66,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_PROVIDER, default=PROVIDER_GOOGLE_SHARED): vol.In({
                     PROVIDER_GOOGLE_SHARED: "Google Photos",
                     PROVIDER_LOCAL_FOLDER: "Local Folder",
+                    PRESET_BRIGHTWHEEL_MANUAL: "Brightwheel (manual sync)",
                 })
             }
         )
@@ -127,3 +132,45 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="local_folder", data_schema=schema, errors=errors)
+
+    async def async_step_brightwheel_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Brightwheel preset: configure a local folder that the user populates
+        with photos exported from Brightwheel via a desktop scraper or browser
+        extension. Stored as a plain local_folder entry; no live API access.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            path = _normalize_local_path(self.hass, user_input[CONF_LOCAL_PATH])
+            name = user_input[CONF_ALBUM_NAME].strip()
+            recursive = bool(user_input.get(CONF_RECURSIVE, DEFAULT_RECURSIVE))
+
+            if not path:
+                errors[CONF_LOCAL_PATH] = "invalid_path"
+            else:
+                await self.async_set_unique_id(
+                    f"{DOMAIN}:{PROVIDER_LOCAL_FOLDER}:{path}"
+                )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_PROVIDER: PROVIDER_LOCAL_FOLDER,
+                        CONF_LOCAL_PATH: path,
+                        CONF_RECURSIVE: recursive,
+                        CONF_ALBUM_NAME: name,
+                    },
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_ALBUM_NAME, default="Brightwheel"): str,
+                vol.Required(CONF_LOCAL_PATH, default=DEFAULT_BRIGHTWHEEL_PATH): str,
+                vol.Optional(CONF_RECURSIVE, default=DEFAULT_RECURSIVE): bool,
+            }
+        )
+        return self.async_show_form(
+            step_id="brightwheel_manual", data_schema=schema, errors=errors
+        )

--- a/custom_components/album_slideshow/const.py
+++ b/custom_components/album_slideshow/const.py
@@ -10,6 +10,15 @@ CONF_IMAGE_CACHE_MB = "image_cache_mb"
 PROVIDER_GOOGLE_SHARED = "google_shared"
 PROVIDER_LOCAL_FOLDER = "local_folder"
 
+# Config-flow-only preset that stores a local_folder entry under the hood.
+# Brightwheel sits behind bot detection that rejects non-browser HTTP clients,
+# so live scraping inside Home Assistant is not viable. Users instead run a
+# desktop tool (e.g. https://github.com/remotephone/brightwheel-crawler) or a
+# browser extension (e.g. "Picture/Video Downloader") and drop photos into a
+# folder that Home Assistant watches.
+PRESET_BRIGHTWHEEL_MANUAL = "brightwheel_manual"
+DEFAULT_BRIGHTWHEEL_PATH = "/media/brightwheel"
+
 FILL_COVER = "cover"
 FILL_CONTAIN = "contain"
 FILL_BLUR = "blur"

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/album_slideshow/strings.json
+++ b/custom_components/album_slideshow/strings.json
@@ -24,6 +24,15 @@
           "local_path": "Folder path",
           "recursive": "Include subfolders"
         }
+      },
+      "brightwheel_manual": {
+        "title": "Brightwheel (manual sync)",
+        "description": "Brightwheel cannot be scraped live from Home Assistant. Use a desktop tool (e.g. remotephone/brightwheel-crawler) or a browser extension (e.g. Picture/Video Downloader) to export photos, drop them into the folder below, and this slideshow will pick them up. Default /media/brightwheel works on Home Assistant OS / Supervised; change it if you store media elsewhere.",
+        "data": {
+          "album_name": "Album name",
+          "local_path": "Folder path",
+          "recursive": "Include subfolders"
+        }
       }
     },
     "error": {

--- a/custom_components/album_slideshow/translations/en.json
+++ b/custom_components/album_slideshow/translations/en.json
@@ -24,6 +24,15 @@
           "local_path": "Folder path",
           "recursive": "Include subfolders"
         }
+      },
+      "brightwheel_manual": {
+        "title": "Brightwheel (manual sync)",
+        "description": "Brightwheel cannot be scraped live from Home Assistant. Use a desktop tool (e.g. remotephone/brightwheel-crawler) or a browser extension (e.g. Picture/Video Downloader) to export photos, drop them into the folder below, and this slideshow will pick them up. Default /media/brightwheel works on Home Assistant OS / Supervised; change it if you store media elsewhere.",
+        "data": {
+          "album_name": "Album name",
+          "local_path": "Folder path",
+          "recursive": "Include subfolders"
+        }
       }
     },
     "error": {


### PR DESCRIPTION
## Summary

Adds a "Brightwheel (manual sync)" preset to the config flow. Stored as a regular Local Folder entry with a default path of `/media/brightwheel`, so coordinator/runtime code is unchanged.

## Why not a live scraper?

Brightwheel sits behind bot detection that rejects plain `aiohttp` requests regardless of credential validity. Every public Brightwheel scraper ([remotephone/brightwheel-crawler](https://github.com/remotephone/brightwheel-crawler), [elitwilliams/brightwheel-image-scraper](https://github.com/elitwilliams/brightwheel-image-scraper)) drives a real Chrome via undetected-chromedriver - a stack that cannot ship inside a HACS custom integration.

The previous attempt at a live API client (PR #5) was abandoned for this reason; rc1/rc2 prereleases were deleted.

## What users do instead

Run a desktop scraper or [Picture/Video Downloader](https://chromewebstore.google.com/detail/picture-video-downloader/gljbmiilfgabbipapcmfenedegaklnjb) extension, drop photos into `/media/brightwheel`, and the slideshow displays them.

## Testing

`pytest tests/ -q` -> 87 passed.