### PR TITLE
0.7.0: Apple iCloud Photos shared album provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ config/custom_components/
 
 ---
 
+### Apple Photos (iCloud Shared Album)
+
+1. On iPhone / iPad / Mac, open the album in **Photos**
+2. Tap the share / people icon and enable **Public Website**
+3. Copy the iCloud share link (looks like `https://www.icloud.com/sharedalbum/#B0XXXXXXXXXX`)
+4. Add the integration, choose **Apple iCloud Photos**, and paste the link
+
+> **Note:** Only public iCloud shared albums work. Private "Shared Albums"
+> that require an Apple ID to view are not supported. The link must contain
+> the `#` token. Live-photo movies and videos in the album are skipped.
+
+---
+
 ### Local Folder or NAS
 
 Use any folder accessible to Home Assistant.

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_RECURSIVE,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
+    PROVIDER_ICLOUD_SHARED,
     DEFAULT_RECURSIVE,
 )
 
@@ -42,6 +43,9 @@ def _normalize_local_path(hass, path: str) -> str:
 
 
 ALBUM_URL_RE = re.compile(r"^https?://photos\.app\.goo\.gl/[^/]+/?$")
+ICLOUD_URL_RE = re.compile(
+    r"^https?://(?:www\.)?icloud\.com/sharedalbum/(?:[a-z]{2}-[a-z]{2}/)?#[A-Za-z0-9_-]+/?$"
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -55,12 +59,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._provider = user_input[CONF_PROVIDER]
             if self._provider == PROVIDER_LOCAL_FOLDER:
                 return await self.async_step_local_folder()
+            if self._provider == PROVIDER_ICLOUD_SHARED:
+                return await self.async_step_icloud_shared()
             return await self.async_step_google_shared()
 
         schema = vol.Schema(
             {
                 vol.Required(CONF_PROVIDER, default=PROVIDER_GOOGLE_SHARED): vol.In({
                     PROVIDER_GOOGLE_SHARED: "Google Photos",
+                    PROVIDER_ICLOUD_SHARED: "Apple iCloud Photos",
                     PROVIDER_LOCAL_FOLDER: "Local Folder",
                 })
             }
@@ -95,6 +102,42 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="google_shared", data_schema=schema, errors=errors)
+
+    async def async_step_icloud_shared(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step: Apple iCloud public shared album link."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            url = user_input[CONF_ALBUM_URL].strip()
+            name = user_input[CONF_ALBUM_NAME].strip()
+
+            if not ICLOUD_URL_RE.match(url):
+                errors[CONF_ALBUM_URL] = "invalid_icloud_url"
+            else:
+                await self.async_set_unique_id(
+                    f"{DOMAIN}:{PROVIDER_ICLOUD_SHARED}:{url}"
+                )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_PROVIDER: PROVIDER_ICLOUD_SHARED,
+                        CONF_ALBUM_URL: url,
+                        CONF_ALBUM_NAME: name,
+                    },
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_ALBUM_NAME): str,
+                vol.Required(CONF_ALBUM_URL): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="icloud_shared", data_schema=schema, errors=errors
+        )
 
     async def async_step_local_folder(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}

--- a/custom_components/album_slideshow/const.py
+++ b/custom_components/album_slideshow/const.py
@@ -9,6 +9,7 @@ CONF_IMAGE_CACHE_MB = "image_cache_mb"
 
 PROVIDER_GOOGLE_SHARED = "google_shared"
 PROVIDER_LOCAL_FOLDER = "local_folder"
+PROVIDER_ICLOUD_SHARED = "icloud_shared"
 
 FILL_COVER = "cover"
 FILL_CONTAIN = "contain"

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
+    PROVIDER_ICLOUD_SHARED,
 )
 from .store import SlideshowStore
 
@@ -247,6 +248,8 @@ class AlbumCoordinator(DataUpdateCoordinator):
                 data = await self._update_local_folder()
             elif self.provider == PROVIDER_GOOGLE_SHARED:
                 data = await self._update_google_shared()
+            elif self.provider == PROVIDER_ICLOUD_SHARED:
+                data = await self._update_icloud_shared()
             else:
                 raise UpdateFailed(f"Unsupported provider: {self.provider}")
         except UpdateFailed:
@@ -586,4 +589,32 @@ class AlbumCoordinator(DataUpdateCoordinator):
         return {
             "title": result.get("title") or self.entry.title,
             "items": api_items,
+        }
+
+    async def _update_icloud_shared(self) -> dict[str, Any]:
+        if not self.album_url:
+            raise UpdateFailed("Missing album URL")
+
+        session = async_get_clientsession(self.hass)
+
+        from . import icloud_scraper
+
+        try:
+            title, items = await icloud_scraper.fetch_album(session, self.album_url)
+        except icloud_scraper.ICloudInvalidToken as err:
+            raise UpdateFailed(f"iCloud album not found: {err}") from err
+        except icloud_scraper.ICloudError as err:
+            raise UpdateFailed(f"iCloud shared album error: {err}") from err
+        except Exception as err:  # noqa: BLE001 - surface as UpdateFailed
+            raise UpdateFailed(f"iCloud shared album error: {err}") from err
+
+        if not items:
+            raise UpdateFailed("No photos returned from iCloud shared album")
+
+        _LOGGER.info(
+            "Album scraper: source=icloud_sharedstreams items=%d", len(items)
+        )
+        return {
+            "title": title or self.entry.title,
+            "items": items,
         }

--- a/custom_components/album_slideshow/icloud_scraper.py
+++ b/custom_components/album_slideshow/icloud_scraper.py
@@ -1,0 +1,345 @@
+"""iCloud public shared-album client.
+
+Apple lets users publish a Photos album as a public web link of the form::
+
+    https://www.icloud.com/sharedalbum/#B0XXXXXXXXXXXX
+    https://www.icloud.com/sharedalbum/en-us/#B0XXXXXXXXXXXX
+
+The fragment after ``#`` is the album token. Apple exposes this album to
+the web via two undocumented but long-stable JSON endpoints, hosted on
+geo-sharded ``p{NN}-sharedstreams.icloud.com`` nodes:
+
+1. ``POST /{token}/sharedstreams/webstream`` with body ``{"streamCtag": null}``
+   returns the album metadata: a list of photos (each with a ``photoGuid``
+   and one or more ``derivatives`` keyed by short edge size, each carrying
+   a ``checksum``), and may set ``X-Apple-MMe-Host`` to redirect us to the
+   correct partition.
+2. ``POST /{token}/sharedstreams/webasseturls`` with body
+   ``{"photoGuids": ["...", ...]}`` returns ``items`` keyed by the per-
+   derivative ``checksum``; each item carries ``url_location`` (host) and
+   ``url_path`` (path + signed query string). Concatenate and that's a
+   short-lived signed download URL.
+
+This client returns the highest-resolution image derivative URL per photo
+(skipping live-photo videos and movies).
+
+Same approach used by the long-running community gist
+(https://gist.github.com/fay59/8f719cd81967e0eb2234897491e051ec) and many
+forks. No auth, no captcha, no CSRF - it's a public-share endpoint.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from .coordinator import MediaItem
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default partition Apple's web client starts with; the real partition is
+# returned in ``X-Apple-MMe-Host`` if the album lives elsewhere.
+_DEFAULT_PARTITION = "p23"
+
+# Regex: pull the token out of an iCloud share URL. We accept either the
+# ``#TOKEN`` fragment form (most common) or a query/path style as a
+# fallback. Tokens are alphanumeric strings starting with a capital letter
+# in current iCloud, but we don't lock that down.
+_TOKEN_RE = re.compile(r"#([A-Za-z0-9_-]+)")
+
+_FETCH_TIMEOUT = 30.0
+_MAX_BATCH = 25  # photoGuid batches per webasseturls call
+
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+    "Version/17.0 Safari/605.1.15"
+)
+
+
+class ICloudError(Exception):
+    """Generic iCloud webstream API error."""
+
+
+class ICloudInvalidToken(ICloudError):
+    """The share token isn't recognized (404 / Invalid response)."""
+
+
+@dataclass
+class _Derivative:
+    """One served size of a photo. Apple may return many; we pick max."""
+
+    checksum: str
+    width: int | None
+    height: int | None
+    file_size: int | None
+
+
+@dataclass
+class _Photo:
+    photo_guid: str
+    caption: str | None
+    captured_at_ms: int | None
+    media_asset_type: str | None  # "image" / "video"
+    derivatives: list[_Derivative]
+
+
+def parse_share_url(share_url: str) -> str | None:
+    """Extract the token from a public iCloud shared-album URL."""
+    if not isinstance(share_url, str):
+        return None
+    parsed = urlparse(share_url.strip())
+    host = (parsed.hostname or "").lower()
+    if "icloud.com" not in host:
+        return None
+    # ``#TOKEN`` fragment - the canonical form.
+    if parsed.fragment:
+        first = parsed.fragment.split("&", 1)[0].split("/", 1)[0]
+        if first:
+            return first
+    # Fallback: try to find ``#TOKEN`` anywhere in the raw string.
+    m = _TOKEN_RE.search(share_url)
+    return m.group(1) if m else None
+
+
+def _base_url(partition: str, token: str) -> str:
+    return f"https://{partition}-sharedstreams.icloud.com/{token}/sharedstreams"
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Content-Type": "text/plain",  # what the iCloud web client sends
+        "Accept": "*/*",
+        "Origin": "https://www.icloud.com",
+        "Referer": "https://www.icloud.com/",
+        "User-Agent": _BROWSER_UA,
+    }
+
+
+async def _post_json(
+    session,
+    url: str,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    async def _do() -> dict[str, Any]:
+        async with session.post(url, json=body, headers=_headers()) as resp:
+            status = resp.status
+            text = ""
+            try:
+                text = await resp.text()
+            except Exception:
+                pass
+            _LOGGER.debug(
+                "iCloud: POST %s -> %d (body[:200]=%r)", url, status, text[:200]
+            )
+            if status == 404:
+                raise ICloudInvalidToken(f"Album not found (HTTP 404): {url}")
+            if status >= 400:
+                raise ICloudError(
+                    f"iCloud webstream HTTP {status} on {url} body={text[:200]!r}"
+                )
+            try:
+                import json as _json
+
+                return _json.loads(text) if text else {}
+            except Exception as err:
+                raise ICloudError(
+                    f"iCloud returned non-JSON body on {url}: {err}"
+                ) from err
+
+    return await asyncio.wait_for(_do(), timeout=_FETCH_TIMEOUT)
+
+
+def _parse_apple_iso_ms(value: Any) -> int | None:
+    """Apple uses ISO 8601 strings like ``2024-09-15T13:42:09Z``."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        # Apple sometimes emits ``...+0000`` or ``...Z``. Normalise.
+        s = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def _parse_photos(payload: dict[str, Any]) -> list[_Photo]:
+    photos: list[_Photo] = []
+    for raw in payload.get("photos") or []:
+        if not isinstance(raw, dict):
+            continue
+        guid = raw.get("photoGuid")
+        if not isinstance(guid, str) or not guid:
+            continue
+
+        derivatives_raw = raw.get("derivatives") or {}
+        if not isinstance(derivatives_raw, dict):
+            continue
+
+        derivatives: list[_Derivative] = []
+        for _key, der in derivatives_raw.items():
+            if not isinstance(der, dict):
+                continue
+            checksum = der.get("checksum")
+            if not isinstance(checksum, str) or not checksum:
+                continue
+            try:
+                width = int(der.get("width")) if der.get("width") is not None else None
+            except (TypeError, ValueError):
+                width = None
+            try:
+                height = (
+                    int(der.get("height")) if der.get("height") is not None else None
+                )
+            except (TypeError, ValueError):
+                height = None
+            try:
+                file_size = (
+                    int(der.get("fileSize")) if der.get("fileSize") is not None else None
+                )
+            except (TypeError, ValueError):
+                file_size = None
+            derivatives.append(
+                _Derivative(
+                    checksum=checksum,
+                    width=width,
+                    height=height,
+                    file_size=file_size,
+                )
+            )
+
+        if not derivatives:
+            continue
+
+        media_type = raw.get("mediaAssetType")
+        if not isinstance(media_type, str):
+            media_type = None
+
+        captured = _parse_apple_iso_ms(raw.get("dateCreated")) or _parse_apple_iso_ms(
+            raw.get("batchDateCreated")
+        )
+
+        caption = raw.get("caption") if isinstance(raw.get("caption"), str) else None
+
+        photos.append(
+            _Photo(
+                photo_guid=guid,
+                caption=caption,
+                captured_at_ms=captured,
+                media_asset_type=media_type,
+                derivatives=derivatives,
+            )
+        )
+
+    return photos
+
+
+def _pick_largest(derivatives: list[_Derivative]) -> _Derivative:
+    """Pick the highest-resolution derivative we can.
+
+    Prefer one with both width and height; fall back to fileSize ordering
+    when dimensions aren't reported.
+    """
+    def _score(d: _Derivative) -> tuple[int, int]:
+        area = (d.width or 0) * (d.height or 0)
+        return (area, d.file_size or 0)
+
+    return max(derivatives, key=_score)
+
+
+async def fetch_album(session, share_url: str) -> tuple[str | None, list[MediaItem]]:
+    """Fetch a public iCloud shared album and return ``(title, items)``.
+
+    Movies and live-photo video sidecars are skipped - only still images
+    end up in the returned list.
+    """
+    token = parse_share_url(share_url)
+    if not token:
+        raise ICloudError(
+            "Could not extract album token from URL. Expected a link like "
+            "https://www.icloud.com/sharedalbum/#B0XXXXXXXXXX"
+        )
+
+    base = _base_url(_DEFAULT_PARTITION, token)
+    payload = await _post_json(session, f"{base}/webstream", {"streamCtag": None})
+
+    # Apple may redirect us to the correct partition.
+    new_host = payload.get("X-Apple-MMe-Host")
+    if isinstance(new_host, str) and new_host:
+        new_partition = new_host.split("-sharedstreams", 1)[0]
+        if new_partition and new_partition != _DEFAULT_PARTITION:
+            _LOGGER.debug(
+                "iCloud: redirecting to partition %s (was %s)",
+                new_partition,
+                _DEFAULT_PARTITION,
+            )
+            base = _base_url(new_partition, token)
+            payload = await _post_json(
+                session, f"{base}/webstream", {"streamCtag": None}
+            )
+
+    photos = _parse_photos(payload)
+    title = payload.get("streamName") if isinstance(payload.get("streamName"), str) else None
+    if not photos:
+        return title, []
+
+    # We want the largest-derivative checksum per photo.
+    selected: dict[str, _Derivative] = {}
+    for photo in photos:
+        if photo.media_asset_type and photo.media_asset_type.lower() != "image":
+            # Skip movies and live-photo video sidecars.
+            continue
+        selected[photo.photo_guid] = _pick_largest(photo.derivatives)
+
+    if not selected:
+        return title, []
+
+    # Resolve signed URLs in batches via webasseturls.
+    checksum_to_url: dict[str, str] = {}
+    guids = list(selected.keys())
+    for i in range(0, len(guids), _MAX_BATCH):
+        batch = guids[i : i + _MAX_BATCH]
+        urls_resp = await _post_json(
+            session, f"{base}/webasseturls", {"photoGuids": batch}
+        )
+        items = urls_resp.get("items")
+        if not isinstance(items, dict):
+            continue
+        for checksum, info in items.items():
+            if not isinstance(info, dict):
+                continue
+            location = info.get("url_location")
+            path = info.get("url_path")
+            if not isinstance(location, str) or not isinstance(path, str):
+                continue
+            checksum_to_url[checksum] = f"https://{location}{path}"
+
+    out: list[MediaItem] = []
+    for photo in photos:
+        if photo.photo_guid not in selected:
+            continue
+        chosen = selected[photo.photo_guid]
+        url = checksum_to_url.get(chosen.checksum)
+        if not url:
+            continue
+        out.append(
+            MediaItem(
+                url=url,
+                width=chosen.width,
+                height=chosen.height,
+                mime_type="image/jpeg",
+                filename=None,
+                captured_at=photo.captured_at_ms,
+                uploaded_at=None,
+                byte_size=chosen.file_size,
+            )
+        )
+
+    return title, out

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/album_slideshow/strings.json
+++ b/custom_components/album_slideshow/strings.json
@@ -16,6 +16,14 @@
           "album_url": "Shared album link"
         }
       },
+      "icloud_shared": {
+        "title": "Apple iCloud Photos",
+        "description": "Paste a public iCloud shared album link, e.g. https://www.icloud.com/sharedalbum/#B0XXXXXXXXXX. The album owner must enable 'Public Website' for the share so it works without an Apple ID.",
+        "data": {
+          "album_name": "Album name",
+          "album_url": "iCloud shared album link"
+        }
+      },
       "local_folder": {
         "title": "Local Folder",
         "description": "Pick a folder path on your Home Assistant filesystem. Use /local/... (maps to /config/www/...) or /media/local/... for NAS-mounted media folders. See the README for details.",
@@ -28,6 +36,7 @@
     },
     "error": {
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
+      "invalid_icloud_url": "That does not look like a public iCloud shared album link. Expected https://www.icloud.com/sharedalbum/#... .",
       "invalid_path": "Path is empty or invalid."
     }
   }

--- a/custom_components/album_slideshow/translations/en.json
+++ b/custom_components/album_slideshow/translations/en.json
@@ -16,6 +16,14 @@
           "album_url": "Shared album link"
         }
       },
+      "icloud_shared": {
+        "title": "Apple iCloud Photos",
+        "description": "Paste a public iCloud shared album link, e.g. https://www.icloud.com/sharedalbum/#B0XXXXXXXXXX. The album owner must enable 'Public Website' for the share so it works without an Apple ID.",
+        "data": {
+          "album_name": "Album name",
+          "album_url": "iCloud shared album link"
+        }
+      },
       "local_folder": {
         "title": "Local Folder",
         "description": "Pick a folder path on your Home Assistant filesystem. Use /local/... (maps to /config/www/...) or /media/local/... for NAS-mounted media folders. See the README for details.",
@@ -28,6 +36,7 @@
     },
     "error": {
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
+      "invalid_icloud_url": "That does not look like a public iCloud shared album link. Expected https://www.icloud.com/sharedalbum/#... .",
       "invalid_path": "Path is empty or invalid."
     }
   }

--- a/tests/test_icloud_scraper.py
+++ b/tests/test_icloud_scraper.py
@@ -1,0 +1,294 @@
+"""Mock tests for the iCloud public shared-album scraper.
+
+These tests exercise the parsing + multi-step request flow against
+fixture JSON modelled on Apple's actual webstream/webasseturls responses.
+No live network calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from custom_components.album_slideshow import icloud_scraper as ic
+
+
+# -- parse_share_url --------------------------------------------------------
+
+
+def test_parse_share_url_fragment():
+    assert (
+        ic.parse_share_url("https://www.icloud.com/sharedalbum/#B0XXXX1234")
+        == "B0XXXX1234"
+    )
+
+
+def test_parse_share_url_with_locale():
+    assert (
+        ic.parse_share_url("https://www.icloud.com/sharedalbum/en-us/#B0Token99")
+        == "B0Token99"
+    )
+
+
+def test_parse_share_url_rejects_non_icloud():
+    assert ic.parse_share_url("https://photos.app.goo.gl/abcd") is None
+
+
+def test_parse_share_url_returns_none_when_no_token():
+    assert ic.parse_share_url("https://www.icloud.com/sharedalbum/") is None
+
+
+# -- Fake aiohttp double ----------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def text(self):
+        if isinstance(self._payload, str):
+            return self._payload
+        try:
+            return json.dumps(self._payload)
+        except Exception:
+            return ""
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        # url-substring -> handler(body) -> _FakeResponse
+        self._handlers: dict[str, Any] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def on(self, url_substring: str, handler) -> None:
+        self._handlers[url_substring] = handler
+
+    def post(self, url, json=None, headers=None, **kwargs):  # noqa: A002
+        self.calls.append({"url": url, "json": json})
+        for sub, handler in self._handlers.items():
+            if sub in url:
+                return handler(url, json or {})
+        raise AssertionError(f"No handler for POST {url}")
+
+
+# -- Fixture builders -------------------------------------------------------
+
+
+def _photo(
+    guid: str,
+    *,
+    derivatives: dict[str, dict[str, Any]],
+    media_type: str = "image",
+    date: str | None = "2024-09-15T13:42:09Z",
+) -> dict[str, Any]:
+    return {
+        "photoGuid": guid,
+        "mediaAssetType": media_type,
+        "dateCreated": date,
+        "derivatives": derivatives,
+    }
+
+
+def _webstream_payload(photos: list[dict[str, Any]], stream_name: str = "My Album") -> dict[str, Any]:
+    return {"streamName": stream_name, "photos": photos}
+
+
+def _webasseturls_payload(checksum_to_loc: dict[str, tuple[str, str]]) -> dict[str, Any]:
+    return {
+        "items": {
+            chk: {"url_location": loc, "url_path": path}
+            for chk, (loc, path) in checksum_to_loc.items()
+        }
+    }
+
+
+# -- fetch_album end-to-end -------------------------------------------------
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_fetch_album_picks_largest_derivative_per_photo():
+    session = _FakeSession()
+    photos = [
+        _photo(
+            "GUID-1",
+            derivatives={
+                "405": {"checksum": "small1", "width": 405, "height": 270, "fileSize": 50_000},
+                "1200": {"checksum": "med1", "width": 1200, "height": 800, "fileSize": 250_000},
+                "2880": {"checksum": "big1", "width": 2880, "height": 1920, "fileSize": 900_000},
+            },
+        ),
+        _photo(
+            "GUID-2",
+            derivatives={
+                "1200": {"checksum": "med2", "width": 1200, "height": 800, "fileSize": 220_000},
+                "2880": {"checksum": "big2", "width": 2880, "height": 1920, "fileSize": 880_000},
+            },
+        ),
+    ]
+
+    session.on(
+        "/webstream",
+        lambda url, body: _FakeResponse(200, _webstream_payload(photos)),
+    )
+    session.on(
+        "/webasseturls",
+        lambda url, body: _FakeResponse(
+            200,
+            _webasseturls_payload(
+                {
+                    "big1": ("cvws.icloud-content.com", "/Bx/big1?o=foo"),
+                    "big2": ("cvws.icloud-content.com", "/Bx/big2?o=bar"),
+                }
+            ),
+        ),
+    )
+
+    title, items = _run(
+        ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#B0AAA1111")
+    )
+    assert title == "My Album"
+    assert len(items) == 2
+    urls = sorted(it.url for it in items)
+    assert urls == [
+        "https://cvws.icloud-content.com/Bx/big1?o=foo",
+        "https://cvws.icloud-content.com/Bx/big2?o=bar",
+    ]
+    # Largest derivative dimensions are propagated.
+    assert all(it.width == 2880 and it.height == 1920 for it in items)
+    # Apple ISO timestamp parsed to epoch ms.
+    assert all(it.captured_at and it.captured_at > 1_000_000_000_000 for it in items)
+
+
+def test_fetch_album_skips_videos_and_live_photos():
+    session = _FakeSession()
+    photos = [
+        _photo(
+            "G1",
+            derivatives={"1": {"checksum": "c1", "width": 1, "height": 1, "fileSize": 1}},
+            media_type="image",
+        ),
+        _photo(
+            "G2",
+            derivatives={"2": {"checksum": "c2", "width": 1, "height": 1, "fileSize": 1}},
+            media_type="video",
+        ),
+    ]
+    session.on("/webstream", lambda url, body: _FakeResponse(200, _webstream_payload(photos)))
+    session.on(
+        "/webasseturls",
+        lambda url, body: _FakeResponse(
+            200, _webasseturls_payload({"c1": ("h", "/p?x")})
+        ),
+    )
+
+    _, items = _run(
+        ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#B0AAA1111")
+    )
+    assert [it.url for it in items] == ["https://h/p?x"]
+
+
+def test_fetch_album_follows_xapple_mme_host_redirect():
+    session = _FakeSession()
+    photos = [
+        _photo(
+            "G1",
+            derivatives={"1": {"checksum": "c1", "width": 1, "height": 1, "fileSize": 1}},
+        ),
+    ]
+
+    call_count = {"webstream": 0}
+
+    def webstream_handler(url, body):
+        call_count["webstream"] += 1
+        if "p23-sharedstreams" in url:
+            # First call: tell client to retry on a different partition.
+            payload = {"X-Apple-MMe-Host": "p52-sharedstreams.icloud.com", "photos": []}
+        else:
+            payload = _webstream_payload(photos)
+        return _FakeResponse(200, payload)
+
+    session.on("/webstream", webstream_handler)
+    session.on(
+        "/webasseturls",
+        lambda url, body: _FakeResponse(
+            200, _webasseturls_payload({"c1": ("h", "/p")})
+        ),
+    )
+
+    title, items = _run(
+        ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#B0AAA1111")
+    )
+    assert call_count["webstream"] == 2
+    assert len(items) == 1
+    # Both calls hit the right token.
+    assert all("B0AAA1111" in c["url"] for c in session.calls)
+    # Second call went to p52, not p23.
+    second = session.calls[1]["url"]
+    assert "p52-sharedstreams" in second
+
+
+def test_fetch_album_raises_invalid_token_on_404():
+    session = _FakeSession()
+    session.on("/webstream", lambda url, body: _FakeResponse(404, {"error": "not found"}))
+    with pytest.raises(ic.ICloudInvalidToken):
+        _run(ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#bogus"))
+
+
+def test_fetch_album_returns_empty_when_album_is_empty():
+    session = _FakeSession()
+    session.on(
+        "/webstream",
+        lambda url, body: _FakeResponse(200, {"streamName": "Empty", "photos": []}),
+    )
+    title, items = _run(
+        ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#B0Empty00")
+    )
+    assert title == "Empty"
+    assert items == []
+
+
+def test_fetch_album_batches_webasseturls_when_many_photos():
+    session = _FakeSession()
+    photos = [
+        _photo(
+            f"G{i}",
+            derivatives={"1": {"checksum": f"c{i}", "width": 100, "height": 100, "fileSize": 1}},
+        )
+        for i in range(60)
+    ]
+    session.on("/webstream", lambda url, body: _FakeResponse(200, _webstream_payload(photos)))
+
+    asseturls_call_count = {"n": 0, "guids_seen": []}
+
+    def asseturls_handler(url, body):
+        asseturls_call_count["n"] += 1
+        guids = body.get("photoGuids") or []
+        asseturls_call_count["guids_seen"].extend(guids)
+        return _FakeResponse(
+            200,
+            _webasseturls_payload(
+                {f"c{int(g[1:])}": ("h", f"/{g}") for g in guids}
+            ),
+        )
+
+    session.on("/webasseturls", asseturls_handler)
+
+    _, items = _run(
+        ic.fetch_album(session, "https://www.icloud.com/sharedalbum/#B0BatchOK")
+    )
+    assert len(items) == 60
+    # 60 photos, default batch size 25 => 3 webasseturls calls.
+    assert asseturls_call_count["n"] == 3
+    assert sorted(asseturls_call_count["guids_seen"]) == sorted(p["photoGuid"] for p in photos)


### PR DESCRIPTION
## v0.7.0: Apple iCloud Photos shared albums

Adds a third media provider so an album entity can stream a public iCloud Photos shared album.

### How it works
- Uses Apple's unauthenticated webstream + webasseturls JSON endpoints (the same protocol the iCloud shared-album web viewer uses).
- No login, cookies, captcha, or bot-wall workarounds.
- Honours Apple's X-Apple-MMe-Host partition redirect.
- Per photo: picks the largest available derivative (by area, then file size).
- Resolves short-lived signed CDN URLs in batches of 25.
- Skips live-photo movies and video attachments.

### How to use
1. On iPhone / iPad / Mac, open the album in **Photos**.
2. Enable **Public Website** for the share.
3. Copy the link (looks like https://www.icloud.com/sharedalbum/#B0XXXXXXXXXX).
4. Add the integration, choose **Apple iCloud Photos**, paste the link.

> Only public iCloud shared albums work. Private "Shared Albums" that require an Apple ID are not supported.

### Tests
- 6 new mock tests cover URL parsing, largest-derivative selection, video skipping, X-Apple-MMe-Host retry, 404 -> `ICloudInvalidToken`, empty albums, and batching. All 97 tests pass.

### Status
Tagged as a **prerelease** (`v0.7.0-rc1`) until verified end-to-end against a real iCloud share URL.