### PR TITLE
feat: EXIF metadata, GPS, and reverse geocoding for local/NAS folders

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify manifest.json version matches the tag
+        id: meta
+        run: |
+          VERSION=$(python3 -c "import json;print(json.load(open('custom_components/album_slideshow/manifest.json'))['version'])")
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "manifest_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_version=$TAG" >> "$GITHUB_OUTPUT"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::manifest.json version ($VERSION) does not match tag ($TAG)"
+            exit 1
+          fi
+
+      - name: Build album_slideshow.zip
+        run: |
+          cd custom_components/album_slideshow
+          zip -r "$GITHUB_WORKSPACE/album_slideshow.zip" . \
+            -x "__pycache__/*" "*.pyc" ".DS_Store"
+          ls -la "$GITHUB_WORKSPACE/album_slideshow.zip"
+
+      - name: Attach asset to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: album_slideshow.zip
+          fail_on_unmatched_files: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+          pip install voluptuous aiohttp
+      - name: Run pytest
+        run: pytest tests/ -q

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ All behavior is exposed as Home Assistant entities. Adjust everything live witho
 - NAS mounted directories
 - Optional recursive scanning
 
+### 📍 EXIF & Location (local / NAS)
+- Reads EXIF capture date (and `OffsetTimeOriginal` when present) so date-filter modes work for local files too
+- Surfaces EXIF GPS as `latitude` / `longitude` camera attributes
+- Optional reverse geocoding via OpenStreetMap Nominatim for a human-readable `location` (e.g. `"Lisbon, Portugal"`); per-album opt-out in the integration's Configure dialog
+
 ### 🗓 Filter & Order by Date
 - Date filter: last 7 / 30 / 365 days, this month, this year, **On this day** memories
 - Order modes: random, album order, **newest taken**, **oldest taken**, **newest added**, **oldest added**
@@ -155,6 +160,37 @@ For NAS:
 - Mount it first
 - Use the mounted path
 
+#### 📍 EXIF capture date & location (local / NAS only)
+
+For local-folder entries the integration reads EXIF metadata in the
+background after every refresh:
+
+- **Capture date** — `DateTimeOriginal` is preferred; if missing, the file's
+  modification time is used so date-based ordering still works for
+  screenshots and scans. When `OffsetTimeOriginal` is present (most modern
+  cameras and phones) it is honoured; otherwise the timestamp is interpreted
+  as the host's local time.
+- **GPS coordinates** — `GPSLatitude`/`GPSLongitude` are exposed as the
+  `latitude` / `longitude` camera attributes. `(0, 0)` "null island" stamps
+  are ignored.
+- **Reverse-geocoded location** — by default the integration calls the
+  public [Nominatim](https://nominatim.openstreetmap.org/) (OpenStreetMap)
+  service to translate coordinates into a human-readable label such as
+  `"Lisbon, Portugal"`, exposed as the `location` attribute. Coordinates
+  are rounded to **~100 m** before lookup and the answer is cached on disk,
+  so the same neighbourhood is only ever fetched once. Nominatim's
+  free-tier policy (1 req/sec, identifying User-Agent) is respected.
+
+**Privacy / opt-out:** if you'd rather not send any coordinates to
+OpenStreetMap, open *Settings → Devices & Services → Album Slideshow → your
+album → Configure* and turn off **Reverse-geocode EXIF GPS coordinates**.
+The `latitude`/`longitude` attributes still work; only the `location`
+label is suppressed. The opt-out is per-album.
+
+Progress for both phases is exposed as the **Enrichment progress**
+diagnostic sensor (percent complete, with `phase`, `exif_done`,
+`geocode_done` etc. as attributes).
+
 ---
 
 ## 🧩 Entities Created
@@ -182,11 +218,12 @@ Each album you configure creates the following entities in Home Assistant.
 
 ### 📊 Sensors
 
-| Entity | Description |
-|--------|------------|
-| Album title | Title of the source album |
-| Media count | Number of images currently available |
-| Image cache usage *(diagnostic)* | Current download cache size in MB |
+| Entity | Source | Description |
+|--------|--------|-------------|
+| Album title | All | Title of the source album |
+| Media count | All | Number of images currently available |
+| Image cache usage *(diagnostic)* | All | Current download cache size in MB |
+| Enrichment progress *(diagnostic)* | Local folder | Percent of files whose EXIF/GPS has been read (and, when enabled, reverse-geocoded). Attributes include `phase`, `exif_done`/`exif_total`, `geocode_done`/`geocode_total`. |
 
 ---
 
@@ -203,10 +240,13 @@ The slideshow camera exposes per-frame metadata as attributes (use with `state_a
 | `current_filename` | string \| null | Source filename when known |
 | `current_url` | string \| null | URL of the current slide |
 | `current_is_portrait` | bool \| null | Orientation of the current slide |
-| `captured_at` | string \| list \| null | ISO-8601 capture date. List of `[primary, partner]` when paired (top/left first) |
+| `captured_at` | string \| list \| null | ISO-8601 capture date. List of `[primary, partner]` when paired (top/left first). For local files this is read from EXIF (or the file's mtime as a fallback). |
 | `captured_at_primary` | string \| null | Capture date of the primary image only |
 | `uploaded_at` | string \| null | ISO-8601 date when added to the album (Google Photos only) |
 | `byte_size` | int \| null | Original file size in bytes (Google Photos only) |
+| `latitude` | float \| null | EXIF GPS latitude in decimal degrees (local folder only) |
+| `longitude` | float \| null | EXIF GPS longitude in decimal degrees (local folder only) |
+| `location` | string \| null | Reverse-geocoded label (e.g. `"Lisbon, Portugal"`). Empty when reverse-geocoding is disabled or has not yet completed for this file. |
 | `paused` | bool | Whether the slideshow is paused |
 | `date_filter` | string | Active date filter mode |
 | `frame_id` | int | Monotonic counter incremented on every committed slide. Used by the [card](#-album-slideshow-card) to detect new frames |

--- a/custom_components/album_slideshow/camera.py
+++ b/custom_components/album_slideshow/camera.py
@@ -231,6 +231,11 @@ class AlbumSlideshowCamera(Camera):
             "captured_at_primary": captured_at,
             "uploaded_at": _ts_to_iso(getattr(cur, "uploaded_at", None)),
             "byte_size": getattr(cur, "byte_size", None),
+            # GPS + reverse-geocoded label come from EXIF for local-folder
+            # entries; Google albums leave these as ``None``.
+            "latitude": getattr(cur, "latitude", None),
+            "longitude": getattr(cur, "longitude", None),
+            "location": getattr(cur, "location", None),
             "slide_interval": int(self.store.slide_interval),
             "fill_mode": self.store.fill_mode,
             "portrait_mode": self.store.portrait_mode,

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
@@ -14,6 +15,8 @@ from .const import (
     CONF_ALBUM_URL,
     CONF_LOCAL_PATH,
     CONF_RECURSIVE,
+    CONF_REVERSE_GEOCODE,
+    DEFAULT_REVERSE_GEOCODE,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
     DEFAULT_RECURSIVE,
@@ -49,6 +52,21 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         self._provider: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Return the options flow handler.
+
+        Only local-folder entries expose user-tunable options today (the
+        reverse-geocode toggle); Google entries get a no-op handler so
+        that the "Configure" button doesn't appear empty in the UI.
+        """
+        if config_entry.data.get(CONF_PROVIDER) == PROVIDER_LOCAL_FOLDER:
+            return LocalFolderOptionsFlow(config_entry)
+        return _NoOptionsFlow(config_entry)
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
@@ -127,3 +145,46 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="local_folder", data_schema=schema, errors=errors)
+
+
+class LocalFolderOptionsFlow(config_entries.OptionsFlow):
+    """Options for local-folder entries.
+
+    Currently exposes a single toggle: ``reverse_geocode``. Users with
+    privacy concerns about handing EXIF GPS coordinates to an external
+    OSM endpoint can turn this off; the GPS coordinates remain available
+    as ``latitude``/``longitude`` attributes regardless.
+    """
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_REVERSE_GEOCODE, DEFAULT_REVERSE_GEOCODE
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_REVERSE_GEOCODE, default=bool(current)
+                ): bool,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+
+class _NoOptionsFlow(config_entries.OptionsFlow):
+    """Fallback options flow for providers that expose nothing tunable."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        return self.async_create_entry(title="", data={})

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -63,10 +63,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Only local-folder entries expose user-tunable options today (the
         reverse-geocode toggle); Google entries get a no-op handler so
         that the "Configure" button doesn't appear empty in the UI.
+
+        Note: do NOT pass ``config_entry`` to the OptionsFlow constructor.
+        Since Home Assistant 2024.12 the base class manages
+        ``self.config_entry`` as a property and assigning to it in
+        ``__init__`` raises (the symptom is a 500 when the user clicks
+        Configure).
         """
         if config_entry.data.get(CONF_PROVIDER) == PROVIDER_LOCAL_FOLDER:
-            return LocalFolderOptionsFlow(config_entry)
-        return _NoOptionsFlow(config_entry)
+            return LocalFolderOptionsFlow()
+        return _NoOptionsFlow()
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
@@ -154,10 +160,11 @@ class LocalFolderOptionsFlow(config_entries.OptionsFlow):
     privacy concerns about handing EXIF GPS coordinates to an external
     OSM endpoint can turn this off; the GPS coordinates remain available
     as ``latitude``/``longitude`` attributes regardless.
-    """
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
+    ``self.config_entry`` is provided by ``OptionsFlow`` as a managed
+    property (HA 2024.12+); we deliberately do NOT define ``__init__``
+    or assign to it, since doing so raises in newer cores.
+    """
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -180,9 +187,6 @@ class LocalFolderOptionsFlow(config_entries.OptionsFlow):
 
 class _NoOptionsFlow(config_entries.OptionsFlow):
     """Fallback options flow for providers that expose nothing tunable."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/album_slideshow/const.py
+++ b/custom_components/album_slideshow/const.py
@@ -6,6 +6,13 @@ CONF_ALBUM_NAME = "album_name"
 CONF_LOCAL_PATH = "local_path"
 CONF_RECURSIVE = "recursive"
 CONF_IMAGE_CACHE_MB = "image_cache_mb"
+# Local-folder option: when True (default) the coordinator does best-effort
+# reverse geocoding of EXIF GPS coordinates via the public Nominatim
+# (OpenStreetMap) endpoint and exposes a human-readable ``location``
+# attribute. Users with privacy concerns can disable this from the
+# integration's options dialog.
+CONF_REVERSE_GEOCODE = "reverse_geocode"
+DEFAULT_REVERSE_GEOCODE = True
 
 PROVIDER_GOOGLE_SHARED = "google_shared"
 PROVIDER_LOCAL_FOLDER = "local_folder"

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import json
@@ -20,6 +21,8 @@ from .const import (
     CONF_ALBUM_URL,
     CONF_LOCAL_PATH,
     CONF_RECURSIVE,
+    CONF_REVERSE_GEOCODE,
+    DEFAULT_REVERSE_GEOCODE,
     DOMAIN,
     PROVIDER_GOOGLE_SHARED,
     PROVIDER_LOCAL_FOLDER,
@@ -42,6 +45,19 @@ class MediaItem:
     uploaded_at: int | None = None
     # File size of the original asset in bytes, when known.
     byte_size: int | None = None
+    # GPS coordinates from EXIF (local-folder provider only); decimal
+    # degrees, signed (negative = South / West). ``location`` is a
+    # human-readable reverse-geocoded label such as
+    # ``"Lisbon, Portugal"`` and may be ``None`` even when coordinates
+    # are present (cache miss, opt-out, or geocoder offline).
+    latitude: float | None = None
+    longitude: float | None = None
+    location: str | None = None
+    # True once the local-folder EXIF reader has visited this file.
+    # Prevents re-reading EXIF on every coordinator refresh and lets the
+    # background enrichment task skip already-processed files even after
+    # an HA restart (the flag round-trips through the items cache).
+    exif_scanned: bool = False
 
 
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"}
@@ -205,10 +221,345 @@ def _looks_like_video(raw: dict[str, Any]) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Local-folder EXIF + reverse-geocode helpers
+# ---------------------------------------------------------------------------
+
+# EXIF tag ids we care about. These are stable IANA-registered numbers, so
+# we can use them directly without depending on ``PIL.ExifTags.TAGS``
+# label lookups (which change wording across Pillow versions).
+_EXIF_TAG_DATETIME_ORIGINAL = 36867       # DateTimeOriginal
+_EXIF_TAG_OFFSET_TIME_ORIGINAL = 36881    # OffsetTimeOriginal (e.g. "+02:00")
+_EXIF_TAG_DATETIME = 306                  # DateTime (modification time)
+_EXIF_TAG_GPS_IFD = 34853                 # Pointer to the GPS IFD
+_EXIF_GPS_LAT_REF = 1                     # "N" / "S"
+_EXIF_GPS_LAT = 2                         # rational tuple
+_EXIF_GPS_LON_REF = 3                     # "E" / "W"
+_EXIF_GPS_LON = 4                         # rational tuple
+
+# Nominatim (OpenStreetMap) is free but rate-limited to 1 request/second
+# per IP and asks integrators to identify themselves with a descriptive
+# User-Agent. See https://operations.osmfoundation.org/policies/nominatim/
+_NOMINATIM_ENDPOINT = "https://nominatim.openstreetmap.org/reverse"
+_NOMINATIM_MIN_INTERVAL_S = 1.1
+_NOMINATIM_TIMEOUT_S = 20
+
+# How many EXIF reads to perform between cache flushes. Bigger batches
+# mean fewer Store writes but more rework if HA is killed mid-scan.
+_EXIF_BATCH_SAVE = 25
+_GEOCODE_BATCH_SAVE = 10
+
+# Inserted between background-enrichment iterations so the event loop
+# stays responsive on the fast path (items that are already scanned and
+# need zero work).
+_ENRICHMENT_FAST_PATH_YIELD_EVERY = 100
+
+
+def _gps_to_decimal(dms: Any, ref: Any) -> float | None:
+    """Convert an EXIF GPS ``(deg, min, sec)`` rational tuple to a signed decimal.
+
+    ``ref`` is the matching reference tag (``"N"``/``"S"`` for latitude or
+    ``"E"``/``"W"`` for longitude). Returns ``None`` when the inputs are
+    malformed or out of the legal coordinate range.
+    """
+    if not isinstance(dms, (tuple, list)) or len(dms) != 3:
+        return None
+    try:
+        deg = float(dms[0])
+        minutes = float(dms[1])
+        sec = float(dms[2])
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    value = deg + minutes / 60.0 + sec / 3600.0
+    if isinstance(ref, bytes):
+        try:
+            ref = ref.decode("ascii", errors="ignore")
+        except Exception:
+            ref = ""
+    if isinstance(ref, str) and ref.strip().upper() in {"S", "W"}:
+        value = -value
+    if not (-180.0 <= value <= 180.0):
+        return None
+    return value
+
+
+def _geocode_cache_key(lat: float, lon: float) -> str:
+    """Return a stable cache key for a coordinate pair.
+
+    Coordinates are rounded to three decimal places (~111 m precision),
+    which is more than enough resolution for a city/neighbourhood label
+    while still folding hundreds of nearby photos into a single
+    Nominatim call. ``-0.0`` is normalised to ``0.0`` so the cache key
+    is identical regardless of which sign of zero the EXIF rounded into.
+    """
+    lat_r = round(float(lat), 3)
+    lon_r = round(float(lon), 3)
+    # ``round`` can yield ``-0.0`` for tiny negative inputs.
+    if lat_r == 0:
+        lat_r = 0.0
+    if lon_r == 0:
+        lon_r = 0.0
+    return f"{lat_r:.3f},{lon_r:.3f}"
+
+
+def _parse_exif_datetime(raw: Any, offset_raw: Any) -> int | None:
+    """Parse an EXIF ``DateTimeOriginal``/``DateTime`` string to epoch ms.
+
+    EXIF stores datetimes as ``"YYYY:MM:DD HH:MM:SS"`` without a timezone.
+    If the companion ``OffsetTimeOriginal`` tag is present (introduced
+    with EXIF 2.31, common on modern cameras and phones) we use it. When
+    it's missing we treat the value as the host's local time, which is
+    the closest thing to "what the user expects" for cameras that don't
+    record an offset.
+    """
+    from datetime import datetime, timezone
+
+    if not isinstance(raw, str):
+        return None
+    raw = raw.strip()
+    if not raw or raw.startswith(("0000", "    ")):
+        return None
+    try:
+        dt = datetime.strptime(raw, "%Y:%m:%d %H:%M:%S")
+    except ValueError:
+        return None
+
+    offset_str: str | None = None
+    if isinstance(offset_raw, bytes):
+        try:
+            offset_str = offset_raw.decode("ascii", errors="ignore").strip()
+        except Exception:
+            offset_str = None
+    elif isinstance(offset_raw, str):
+        offset_str = offset_raw.strip()
+
+    if offset_str:
+        try:
+            offset_dt = datetime.fromisoformat(f"2000-01-01T00:00:00{offset_str}")
+            dt = dt.replace(tzinfo=offset_dt.tzinfo)
+        except ValueError:
+            dt = dt.astimezone().replace(tzinfo=None).astimezone()
+    else:
+        # Interpret as the host's local time.
+        dt = dt.astimezone()
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    try:
+        return int(dt.timestamp() * 1000)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _read_local_exif(path: Path) -> dict[str, Any]:
+    """Read EXIF metadata for a local file.
+
+    Returns a dict with any of the keys ``captured_at`` (epoch ms),
+    ``latitude`` and ``longitude``. All keys are optional - missing
+    metadata is just omitted. ``captured_at`` always falls back to the
+    file's modification time so date-sorting works even for screenshots
+    and scans without EXIF.
+
+    Designed to be called from an executor thread: it does only
+    synchronous Pillow + filesystem I/O.
+    """
+    out: dict[str, Any] = {}
+
+    # mtime fallback for captured_at. Cameras that don't record EXIF
+    # (screenshots, scans, certain Android camera apps) still need a
+    # plausible "taken on" timestamp for the date-filter sensors and
+    # ordering. The EXIF parse below overrides this when present.
+    try:
+        out["captured_at"] = int(path.stat().st_mtime * 1000)
+    except OSError:
+        pass
+
+    try:
+        from PIL import Image
+    except Exception:  # pragma: no cover - Pillow ships with HA core
+        return out
+
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif()
+            if not exif:
+                return out
+
+            dt_raw = exif.get(_EXIF_TAG_DATETIME_ORIGINAL) or exif.get(
+                _EXIF_TAG_DATETIME
+            )
+            offset_raw = exif.get(_EXIF_TAG_OFFSET_TIME_ORIGINAL)
+            parsed = _parse_exif_datetime(dt_raw, offset_raw)
+            if parsed is not None:
+                out["captured_at"] = parsed
+
+            gps = None
+            try:
+                gps = exif.get_ifd(_EXIF_TAG_GPS_IFD) or None
+            except Exception:
+                gps = None
+            if gps:
+                lat = _gps_to_decimal(
+                    gps.get(_EXIF_GPS_LAT), gps.get(_EXIF_GPS_LAT_REF)
+                )
+                lon = _gps_to_decimal(
+                    gps.get(_EXIF_GPS_LON), gps.get(_EXIF_GPS_LON_REF)
+                )
+                if lat is not None and lon is not None:
+                    # Null Island guard: GPS chips and some editors stamp
+                    # ``(0, 0)`` when the fix is invalid. Treat that as no
+                    # location rather than dropping every such photo onto
+                    # the equator off the African coast.
+                    if abs(lat) < 1e-6 and abs(lon) < 1e-6:
+                        return out
+                    out["latitude"] = lat
+                    out["longitude"] = lon
+    except Exception as err:
+        _LOGGER.debug("EXIF: failed to read %s: %s", path, err)
+
+    return out
+
+
+def _format_nominatim_location(payload: dict[str, Any]) -> str | None:
+    """Turn a Nominatim reverse-geocode response into a short label.
+
+    Prefers ``city`` > ``town`` > ``village`` > ``municipality`` >
+    ``county`` for the locality portion, plus ``country`` when present.
+    Falls back to Nominatim's pre-formatted ``display_name`` (truncated
+    to the first two comma-separated parts) when no recognisable
+    locality fields are present.
+    """
+    if not isinstance(payload, dict):
+        return None
+    address = payload.get("address") if isinstance(payload.get("address"), dict) else {}
+    locality = None
+    for key in ("city", "town", "village", "hamlet", "municipality", "county", "state"):
+        val = address.get(key)
+        if isinstance(val, str) and val.strip():
+            locality = val.strip()
+            break
+    country = address.get("country") if isinstance(address.get("country"), str) else None
+
+    if locality and country:
+        return f"{locality}, {country}"
+    if locality:
+        return locality
+    if isinstance(country, str) and country.strip():
+        return country.strip()
+
+    display = payload.get("display_name")
+    if isinstance(display, str) and display.strip():
+        parts = [p.strip() for p in display.split(",") if p.strip()]
+        if len(parts) >= 2:
+            return ", ".join(parts[:2])
+        if parts:
+            return parts[0]
+    return None
+
+
+async def _nominatim_lookup(
+    session: Any,
+    lat: float,
+    lon: float,
+    user_agent: str,
+) -> str | None:
+    """Reverse-geocode a coordinate pair via Nominatim.
+
+    Returns a human-readable label or ``None`` if the lookup failed or
+    the response had no useful address. Never raises - geocoding is
+    best-effort and a failure must never stop the slideshow.
+    """
+    params = {
+        "format": "jsonv2",
+        "lat": f"{lat:.5f}",
+        "lon": f"{lon:.5f}",
+        "zoom": "10",      # Roughly city-level - we don't need street precision.
+        "addressdetails": "1",
+    }
+    headers = {
+        "User-Agent": user_agent,
+        "Accept": "application/json",
+        "Accept-Language": "en",
+    }
+    try:
+        async with async_timeout.timeout(_NOMINATIM_TIMEOUT_S):
+            resp = await session.get(
+                _NOMINATIM_ENDPOINT, params=params, headers=headers
+            )
+            if resp.status == 429:
+                _LOGGER.warning(
+                    "Nominatim rate-limited the integration; pausing geocode"
+                )
+                # Honour the policy by sleeping a full second before the
+                # caller schedules another request.
+                await asyncio.sleep(_NOMINATIM_MIN_INTERVAL_S)
+                return None
+            if resp.status >= 400:
+                _LOGGER.debug("Nominatim returned HTTP %s", resp.status)
+                return None
+            try:
+                payload = await resp.json(content_type=None)
+            except Exception:
+                return None
+    except asyncio.CancelledError:
+        raise
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Nominatim lookup failed (%s, %s): %s", lat, lon, err)
+        return None
+
+    return _format_nominatim_location(payload)
+
+
+def _read_manifest_version(integration_dir: Path) -> str:
+    """Best-effort read of ``manifest.json`` version. Returns ``""`` on error."""
+    try:
+        manifest_path = integration_dir / "manifest.json"
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        version = data.get("version")
+        if isinstance(version, str):
+            return version
+    except Exception:
+        pass
+    return ""
+
+
+def _merge_prior_enrichment(
+    new_items: list[MediaItem], prior_items: list[MediaItem]
+) -> None:
+    """Copy EXIF + geocode metadata from prior coordinator items by URL.
+
+    Local-folder scans rebuild the ``MediaItem`` list from scratch on
+    every refresh, but reading EXIF + reverse-geocoding the same files
+    again would be wasteful (and would re-bill the user against the
+    Nominatim rate limit). This in-place merge preserves anything we
+    learned about files whose URL (and therefore path) hasn't changed.
+    """
+    if not prior_items:
+        return
+    prior_by_url: dict[str, MediaItem] = {it.url: it for it in prior_items}
+    for item in new_items:
+        prev = prior_by_url.get(item.url)
+        if prev is None:
+            continue
+        if prev.captured_at is not None and item.captured_at is None:
+            item.captured_at = prev.captured_at
+        if prev.latitude is not None and item.latitude is None:
+            item.latitude = prev.latitude
+        if prev.longitude is not None and item.longitude is None:
+            item.longitude = prev.longitude
+        if prev.location and not item.location:
+            item.location = prev.location
+        if prev.exif_scanned:
+            item.exif_scanned = True
+
 
 class AlbumCoordinator(DataUpdateCoordinator):
     # Bump when the persisted item shape changes incompatibly.
-    _ITEM_CACHE_VERSION = 1
+    _ITEM_CACHE_VERSION = 2
+    # Bump independently of the items cache - the geocode cache is
+    # keyed by coordinate and is safe to keep across item-shape changes.
+    _GEOCODE_CACHE_VERSION = 1
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, store: SlideshowStore) -> None:
         self.hass = hass
@@ -229,6 +580,34 @@ class AlbumCoordinator(DataUpdateCoordinator):
         )
         self._items_cache_loaded: bool = False
 
+        # Reverse-geocode cache. Coordinates rounded to ~100 m via
+        # ``_geocode_cache_key``; mapping value -> label string. Shared
+        # across all items in the album, persisted independently of the
+        # items cache so changes to one don't invalidate the other.
+        self._geocode_cache_store: Store = Store(
+            hass,
+            self._GEOCODE_CACHE_VERSION,
+            f"{DOMAIN}.{entry.entry_id}.geocode",
+        )
+        self._geocode_cache: dict[str, str] = {}
+        self._geocode_cache_loaded: bool = False
+        # Per-coordinator User-Agent so OSM operators can track us if we
+        # ever misbehave. Resolved lazily because __init__ is sync.
+        self._integration_version: str | None = None
+        # Background EXIF + geocode worker. Cancelled and replaced on
+        # every refresh so a stalled run from a previous interval never
+        # accumulates.
+        self._enrichment_task: asyncio.Task | None = None
+        # Progress data exposed to the diagnostic sensor. ``phase`` is
+        # ``None``/``"exif"``/``"geocoding"``/``"done"``.
+        self._enrich_progress: dict[str, Any] = {
+            "phase": None,
+            "exif_total": 0,
+            "exif_done": 0,
+            "geocode_total": 0,
+            "geocode_done": 0,
+        }
+
         super().__init__(
             hass,
             _LOGGER,
@@ -242,6 +621,11 @@ class AlbumCoordinator(DataUpdateCoordinator):
         store.add_listener(_on_store_change)
 
     async def _async_update_data(self) -> dict[str, Any]:
+        # Cancel any in-flight enrichment from a previous interval before
+        # the new scan runs - it would otherwise race against the new
+        # item list and risk re-saving stale data over fresh state.
+        await self._cancel_enrichment()
+
         try:
             if self.provider == PROVIDER_LOCAL_FOLDER:
                 data = await self._update_local_folder()
@@ -260,6 +644,15 @@ class AlbumCoordinator(DataUpdateCoordinator):
             raise
 
         items = data.get("items") or []
+        if self.provider == PROVIDER_LOCAL_FOLDER and items:
+            # Carry forward EXIF/geocode metadata for files we've already
+            # scanned this session; new files get filled in by the
+            # background worker below.
+            prior_items = (self.data or {}).get("items") if isinstance(self.data, dict) else None
+            if prior_items:
+                _merge_prior_enrichment(items, prior_items)
+            self._schedule_enrichment(data)
+
         if items:
             # Only persist non-empty results so we never overwrite a good
             # cache with a transient empty fetch.
@@ -274,6 +667,48 @@ class AlbumCoordinator(DataUpdateCoordinator):
                 return cached
 
         return data
+
+    async def _cancel_enrichment(self) -> None:
+        """Cancel and reap any in-flight background enrichment task."""
+        task = self._enrichment_task
+        if task is None or task.done():
+            self._enrichment_task = None
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        finally:
+            self._enrichment_task = None
+
+    def _schedule_enrichment(self, data: dict[str, Any]) -> None:
+        """Kick off the background EXIF + geocode worker if there's work."""
+        items: list[MediaItem] = data.get("items") or []
+        unscanned = [it for it in items if not it.exif_scanned]
+        if not unscanned:
+            # Even with nothing to do, mark the phase as ``done`` so the
+            # diagnostic sensor stops reporting an in-progress run from
+            # the previous refresh.
+            self._enrich_progress = {
+                "phase": "done",
+                "exif_total": len(items),
+                "exif_done": len(items),
+                "geocode_total": 0,
+                "geocode_done": 0,
+            }
+            return
+        self._enrich_progress = {
+            "phase": "exif",
+            "exif_total": len(items),
+            "exif_done": len(items) - len(unscanned),
+            "geocode_total": 0,
+            "geocode_done": 0,
+        }
+        self._enrichment_task = self.hass.async_create_background_task(
+            self._enrich_items_background(data),
+            name=f"album_slideshow_enrich_{self.entry.entry_id}",
+        )
 
     async def _load_cached_items(self) -> dict[str, Any] | None:
         try:
@@ -302,6 +737,10 @@ class AlbumCoordinator(DataUpdateCoordinator):
                     captured_at=raw.get("captured_at"),
                     uploaded_at=raw.get("uploaded_at"),
                     byte_size=raw.get("byte_size"),
+                    latitude=raw.get("latitude"),
+                    longitude=raw.get("longitude"),
+                    location=raw.get("location"),
+                    exif_scanned=bool(raw.get("exif_scanned", False)),
                 ))
             except Exception:
                 continue
@@ -328,6 +767,10 @@ class AlbumCoordinator(DataUpdateCoordinator):
                     "captured_at": it.captured_at,
                     "uploaded_at": it.uploaded_at,
                     "byte_size": it.byte_size,
+                    "latitude": it.latitude,
+                    "longitude": it.longitude,
+                    "location": it.location,
+                    "exif_scanned": it.exif_scanned,
                 }
                 for it in items
             ],
@@ -395,6 +838,215 @@ class AlbumCoordinator(DataUpdateCoordinator):
             "title": root.name,
             "items": items,
         }
+
+    async def _enrich_items_background(self, data: dict[str, Any]) -> None:
+        """Read EXIF for unscanned local files, then reverse-geocode.
+
+        Runs as a background task so the coordinator's first update can
+        return immediately with the bare file list. Pushes incremental
+        updates to listeners after each EXIF batch so attributes appear
+        on the camera as soon as they are known.
+
+        Cancellation-safe: any progress made before a cancel is
+        persisted via the ``finally`` clause.
+        """
+        items: list[MediaItem] = data.get("items") or []
+        if not items:
+            return
+
+        scanned_since_save = 0
+        try:
+            for idx, item in enumerate(items):
+                if item.exif_scanned:
+                    # Fast path: yield occasionally so we don't starve
+                    # the event loop when (re-)visiting a long list of
+                    # already-processed items.
+                    if idx % _ENRICHMENT_FAST_PATH_YIELD_EVERY == 0:
+                        await asyncio.sleep(0)
+                    continue
+
+                url = item.url
+                if not url.startswith("file://"):
+                    item.exif_scanned = True
+                    continue
+
+                path = Path(url[len("file://"):])
+                try:
+                    info = await self.hass.async_add_executor_job(
+                        _read_local_exif, path
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug("EXIF: executor error for %s: %s", path, err)
+                    info = {}
+
+                if "captured_at" in info:
+                    item.captured_at = info["captured_at"]
+                if "latitude" in info and "longitude" in info:
+                    item.latitude = info["latitude"]
+                    item.longitude = info["longitude"]
+                item.exif_scanned = True
+
+                scanned_since_save += 1
+                self._enrich_progress["exif_done"] = (
+                    self._enrich_progress.get("exif_done", 0) + 1
+                )
+
+                if scanned_since_save >= _EXIF_BATCH_SAVE:
+                    scanned_since_save = 0
+                    await self._save_cached_items(data)
+                    self.async_set_updated_data(data)
+
+            # Flush any tail items before the geocode phase.
+            if scanned_since_save:
+                await self._save_cached_items(data)
+                self.async_set_updated_data(data)
+
+            await self._geocode_items_background(data)
+        except asyncio.CancelledError:
+            _LOGGER.debug("Album enrichment: cancelled, persisting progress")
+            raise
+        finally:
+            # Always flush whatever progress we made, even on cancel.
+            try:
+                await self._save_cached_items(data)
+            except Exception:  # pragma: no cover - storage layer
+                pass
+            # Phase ``done`` lets the diagnostic sensor settle at 100%.
+            self._enrich_progress["phase"] = "done"
+
+    async def _geocode_items_background(self, data: dict[str, Any]) -> None:
+        """Reverse-geocode items with EXIF GPS but no location label yet.
+
+        Honours the ``reverse_geocode`` option (default on) so privacy-
+        conscious users can disable the Nominatim calls without losing
+        the GPS coordinates themselves. Successful labels are written
+        back into the items in-place and persisted via the items cache.
+        """
+        if not bool(
+            self.entry.options.get(CONF_REVERSE_GEOCODE, DEFAULT_REVERSE_GEOCODE)
+            if hasattr(self.entry, "options") and self.entry.options is not None
+            else DEFAULT_REVERSE_GEOCODE
+        ):
+            _LOGGER.debug("Reverse geocode disabled via options; skipping")
+            return
+
+        items: list[MediaItem] = data.get("items") or []
+        candidates: list[MediaItem] = [
+            it
+            for it in items
+            if it.latitude is not None
+            and it.longitude is not None
+            and not it.location
+        ]
+        if not candidates:
+            return
+
+        await self._ensure_geocode_cache_loaded()
+
+        self._enrich_progress["phase"] = "geocoding"
+        self._enrich_progress["geocode_total"] = len(candidates)
+        self._enrich_progress["geocode_done"] = 0
+
+        session = async_get_clientsession(self.hass)
+        user_agent = await self._async_user_agent()
+
+        # Last network call wall-time; used to throttle Nominatim to the
+        # 1 req/sec policy without sleeping for cached lookups.
+        last_call: float = 0.0
+        loop = asyncio.get_event_loop()
+        unsaved = 0
+
+        try:
+            for item in candidates:
+                key = _geocode_cache_key(item.latitude, item.longitude)
+                cached_label = self._geocode_cache.get(key)
+                if cached_label:
+                    item.location = cached_label
+                    self._enrich_progress["geocode_done"] += 1
+                    continue
+
+                # Respect the 1 req/sec Nominatim usage policy.
+                elapsed = loop.time() - last_call
+                if elapsed < _NOMINATIM_MIN_INTERVAL_S:
+                    await asyncio.sleep(_NOMINATIM_MIN_INTERVAL_S - elapsed)
+
+                label = await _nominatim_lookup(
+                    session, item.latitude, item.longitude, user_agent
+                )
+                last_call = loop.time()
+
+                if label:
+                    self._geocode_cache[key] = label
+                    item.location = label
+                    unsaved += 1
+
+                self._enrich_progress["geocode_done"] += 1
+
+                if unsaved >= _GEOCODE_BATCH_SAVE:
+                    unsaved = 0
+                    await self._save_geocode_cache()
+                    await self._save_cached_items(data)
+                    self.async_set_updated_data(data)
+        finally:
+            if unsaved:
+                try:
+                    await self._save_geocode_cache()
+                except Exception:  # pragma: no cover - storage layer
+                    pass
+            try:
+                await self._save_cached_items(data)
+            except Exception:  # pragma: no cover - storage layer
+                pass
+            self.async_set_updated_data(data)
+
+    async def _ensure_geocode_cache_loaded(self) -> None:
+        if self._geocode_cache_loaded:
+            return
+        try:
+            payload = await self._geocode_cache_store.async_load()
+        except Exception as err:  # pragma: no cover - storage layer
+            _LOGGER.debug("Geocode cache: failed to load (%s)", err)
+            payload = None
+        if isinstance(payload, dict):
+            entries = payload.get("entries")
+            if isinstance(entries, dict):
+                self._geocode_cache = {
+                    str(k): str(v)
+                    for k, v in entries.items()
+                    if isinstance(v, str) and v
+                }
+        self._geocode_cache_loaded = True
+
+    async def _save_geocode_cache(self) -> None:
+        try:
+            await self._geocode_cache_store.async_save(
+                {"entries": self._geocode_cache}
+            )
+        except Exception as err:  # pragma: no cover - storage layer
+            _LOGGER.debug("Geocode cache: failed to save (%s)", err)
+
+    async def _async_user_agent(self) -> str:
+        """Return a Nominatim-friendly User-Agent string.
+
+        OSM operations explicitly require integrators to identify
+        themselves; using a generic Python/aiohttp UA gets you blocked.
+        We bundle the integration version (from ``manifest.json``) so
+        operators can correlate issues to releases.
+        """
+        if self._integration_version is None:
+            try:
+                self._integration_version = await self.hass.async_add_executor_job(
+                    _read_manifest_version, Path(__file__).parent
+                )
+            except Exception:
+                self._integration_version = ""
+        version = self._integration_version or "dev"
+        return (
+            f"album_slideshow/{version} "
+            "(+https://github.com/eyalgal/album_slideshow)"
+        )
 
     async def _call_publicalbum(
         self,

--- a/custom_components/album_slideshow/manifest.json
+++ b/custom_components/album_slideshow/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/eyalgal/album_slideshow",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eyalgal/album_slideshow/issues",
-  "requirements": [],
-  "version": "0.7.1"
+  "requirements": ["Pillow"],
+  "version": "0.8.0"
 }

--- a/custom_components/album_slideshow/sensor.py
+++ b/custom_components/album_slideshow/sensor.py
@@ -6,17 +6,24 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, PROVIDER_GOOGLE_SHARED
+from .const import DOMAIN, PROVIDER_GOOGLE_SHARED, PROVIDER_LOCAL_FOLDER
 from .coordinator import AlbumCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     coordinator: AlbumCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    async_add_entities([
+    entities: list[SensorEntity] = [
         AlbumCountSensor(entry, coordinator),
         AlbumTitleSensor(entry, coordinator),
         CacheUsageSensor(entry, coordinator),
-    ])
+    ]
+    if coordinator.provider == PROVIDER_LOCAL_FOLDER:
+        # Diagnostic surface for the local-folder background enrichment
+        # (EXIF reads + reverse-geocode). For Google albums there's no
+        # enrichment work, so this sensor is omitted to keep the device
+        # screen tidy.
+        entities.append(EnrichmentProgressSensor(entry, coordinator))
+    async_add_entities(entities)
 
 
 class _BaseAlbumSensor(SensorEntity):
@@ -92,3 +99,52 @@ class CacheUsageSensor(_BaseAlbumSensor):
         if cam is None:
             return None
         return cam.cache_usage_mb
+
+
+class EnrichmentProgressSensor(_BaseAlbumSensor):
+    """Percent-complete sensor for the local-folder enrichment worker.
+
+    Reports the slower-changing of the two phases:
+    - ``exif``: reading capture date + GPS from EXIF tags.
+    - ``geocoding``: reverse-geocoding GPS to a city/country label.
+
+    Holds at ``100`` when both phases finish and stays there until the
+    next coordinator refresh discovers new files. The ``phase`` and
+    raw counts are surfaced as state attributes so dashboards can show
+    progress text alongside the bar.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = "%"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:map-marker-radius"
+
+    def __init__(self, entry: ConfigEntry, coordinator: AlbumCoordinator) -> None:
+        super().__init__(entry, coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_enrichment_progress"
+        self._attr_name = "Enrichment progress"
+
+    @property
+    def native_value(self):
+        prog = getattr(self.coordinator, "_enrich_progress", None) or {}
+        phase = prog.get("phase")
+        if phase == "geocoding":
+            total = prog.get("geocode_total") or 0
+            done = prog.get("geocode_done") or 0
+        else:
+            total = prog.get("exif_total") or 0
+            done = prog.get("exif_done") or 0
+        if total <= 0:
+            return None
+        return max(0, min(100, round(100 * done / total)))
+
+    @property
+    def extra_state_attributes(self):
+        prog = getattr(self.coordinator, "_enrich_progress", None) or {}
+        return {
+            "phase": prog.get("phase"),
+            "exif_total": prog.get("exif_total", 0),
+            "exif_done": prog.get("exif_done", 0),
+            "geocode_total": prog.get("geocode_total", 0),
+            "geocode_done": prog.get("geocode_done", 0),
+        }

--- a/custom_components/album_slideshow/strings.json
+++ b/custom_components/album_slideshow/strings.json
@@ -30,5 +30,16 @@
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
       "invalid_path": "Path is empty or invalid."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Local Folder options",
+        "description": "Reverse geocoding sends your photos' EXIF GPS coordinates to the public OpenStreetMap Nominatim service (https://nominatim.openstreetmap.org) to look up a human-readable place name. Coordinates are rounded to ~100 m before lookup and cached on disk. Turn this off to keep coordinates entirely local; the latitude and longitude attributes still work either way.",
+        "data": {
+          "reverse_geocode": "Reverse-geocode EXIF GPS coordinates via OpenStreetMap"
+        }
+      }
+    }
   }
 }

--- a/custom_components/album_slideshow/translations/en.json
+++ b/custom_components/album_slideshow/translations/en.json
@@ -30,5 +30,16 @@
       "invalid_album_url": "That does not look like a Google Photos shared album link.",
       "invalid_path": "Path is empty or invalid."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Local Folder options",
+        "description": "Reverse geocoding sends your photos' EXIF GPS coordinates to the public OpenStreetMap Nominatim service (https://nominatim.openstreetmap.org) to look up a human-readable place name. Coordinates are rounded to ~100 m before lookup and cached on disk. Turn this off to keep coordinates entirely local; the latitude and longitude attributes still work either way.",
+        "data": {
+          "reverse_geocode": "Reverse-geocode EXIF GPS coordinates via OpenStreetMap"
+        }
+      }
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,3 +81,82 @@ class _Store:
 
 
 _storage.Store = _Store  # type: ignore[attr-defined]
+
+
+# ``async_timeout.timeout`` is used by coordinator.py around aiohttp calls;
+# tests that exercise those code paths need a no-op async context manager
+# rather than the empty module stub.
+class _NullAsyncTimeout:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+import async_timeout as _async_timeout
+
+_async_timeout.timeout = lambda *a, **kw: _NullAsyncTimeout()  # type: ignore[attr-defined]
+
+
+# config_flow.py imports ``callback`` from homeassistant.core; provide a
+# pass-through decorator that mirrors the real one's behaviour.
+def _callback(func):
+    return func
+
+
+_core.callback = _callback  # type: ignore[attr-defined]
+
+
+# Minimal stubs for the config_entries types used by ConfigFlow + OptionsFlow.
+class _ConfigFlow:
+    VERSION = 1
+    def __init_subclass__(cls, **kwargs):
+        # Accept the ``domain=...`` keyword used by ConfigFlow subclasses.
+        kwargs.pop("domain", None)
+        super().__init_subclass__(**kwargs)
+
+
+class _OptionsFlow:
+    pass
+
+
+_ce.ConfigFlow = _ConfigFlow  # type: ignore[attr-defined]
+_ce.OptionsFlow = _OptionsFlow  # type: ignore[attr-defined]
+
+
+# data_entry_flow.FlowResult is just an alias for dict in older HA cores.
+_make_stub("homeassistant.data_entry_flow")
+import homeassistant.data_entry_flow as _def
+
+_def.FlowResult = dict  # type: ignore[attr-defined]
+
+
+# helpers.entity.EntityCategory is referenced by sensor.py.
+_make_stub("homeassistant.helpers.entity")
+import homeassistant.helpers.entity as _he
+
+
+class _EntityCategory:
+    DIAGNOSTIC = "diagnostic"
+    CONFIG = "config"
+
+
+_he.EntityCategory = _EntityCategory  # type: ignore[attr-defined]
+
+
+# components.sensor: SensorEntity + SensorStateClass.
+_make_stub("homeassistant.components.sensor")
+import homeassistant.components.sensor as _sensor
+
+
+class _SensorEntity:
+    pass
+
+
+class _SensorStateClass:
+    MEASUREMENT = "measurement"
+
+
+_sensor.SensorEntity = _SensorEntity  # type: ignore[attr-defined]
+_sensor.SensorStateClass = _SensorStateClass  # type: ignore[attr-defined]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
 pytest>=7.0
 Pillow>=9.0
+voluptuous>=0.13
+aiohttp>=3.8

--- a/tests/test_local_enrichment.py
+++ b/tests/test_local_enrichment.py
@@ -1,0 +1,443 @@
+"""Tests for the local-folder EXIF + reverse-geocode pipeline.
+
+These cover the pieces that don't need a running HA event loop:
+- ``_gps_to_decimal`` sign + range handling
+- ``_geocode_cache_key`` rounding + ``-0.0`` normalisation
+- ``_read_local_exif`` end-to-end against Pillow-generated JPEGs
+- ``_format_nominatim_location`` field preferences
+- ``_nominatim_lookup`` against a fake aiohttp session
+- ``MediaItem`` round-trip through ``_save_cached_items`` /
+  ``_load_cached_items`` (including the new GPS/location fields and
+  the ``exif_scanned`` skip flag)
+- ``_merge_prior_enrichment`` URL-keyed carry-over
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+from PIL.TiffImagePlugin import IFDRational
+
+from custom_components.album_slideshow import coordinator as c
+from custom_components.album_slideshow.const import (
+    CONF_REVERSE_GEOCODE,
+    DEFAULT_REVERSE_GEOCODE,
+)
+
+
+# ── _gps_to_decimal ────────────────────────────────────────────
+
+def test_gps_to_decimal_north_is_positive():
+    # 37° 25' 19.07" N -> ~37.4220
+    assert c._gps_to_decimal((37, 25, 19.07), "N") == pytest.approx(37.4220, abs=1e-3)
+
+
+def test_gps_to_decimal_south_is_negative():
+    assert c._gps_to_decimal((22, 54, 30), "S") == pytest.approx(-22.9083, abs=1e-3)
+
+
+def test_gps_to_decimal_east_is_positive():
+    assert c._gps_to_decimal((122, 5, 6), "E") == pytest.approx(122.085, abs=1e-3)
+
+
+def test_gps_to_decimal_west_is_negative():
+    assert c._gps_to_decimal((73, 56, 6), "W") == pytest.approx(-73.935, abs=1e-3)
+
+
+def test_gps_to_decimal_handles_bytes_ref():
+    # Some Pillow versions surface ASCII refs as bytes.
+    assert c._gps_to_decimal((10, 0, 0), b"S") == pytest.approx(-10.0)
+
+
+def test_gps_to_decimal_handles_ifdrational():
+    dms = (IFDRational(37), IFDRational(25, 1), IFDRational(1907, 100))
+    assert c._gps_to_decimal(dms, "N") == pytest.approx(37.4220, abs=1e-3)
+
+
+def test_gps_to_decimal_rejects_malformed():
+    assert c._gps_to_decimal(None, "N") is None
+    assert c._gps_to_decimal((1, 2), "N") is None  # wrong arity
+    assert c._gps_to_decimal(("bad", 0, 0), "N") is None
+
+
+def test_gps_to_decimal_rejects_out_of_range():
+    # 200° is past the 180° wraparound; reject rather than silently fold.
+    assert c._gps_to_decimal((200, 0, 0), "N") is None
+
+
+# ── _geocode_cache_key ──────────────────────────────────────────
+
+def test_geocode_cache_key_rounds_to_three_dp():
+    assert c._geocode_cache_key(37.42201234, -122.08491111) == "37.422,-122.085"
+
+
+def test_geocode_cache_key_normalises_negative_zero():
+    # Tiny negative inputs round to ``-0.0`` in IEEE 754; normalise to
+    # the unsigned form so cache keys are stable.
+    key = c._geocode_cache_key(-1e-5, -1e-5)
+    assert "-0.000" not in key
+    assert key == "0.000,0.000"
+
+
+def test_geocode_cache_key_is_stable_across_call():
+    assert c._geocode_cache_key(48.8566, 2.3522) == c._geocode_cache_key(
+        48.8566, 2.3522
+    )
+
+
+# ── _parse_exif_datetime ────────────────────────────────────────
+
+def test_parse_exif_datetime_with_offset_is_offset_aware():
+    # Pin the offset so the result doesn't depend on the test host's TZ.
+    ms = c._parse_exif_datetime("2024:05:18 12:00:00", "+00:00")
+    assert ms == 1716033600000  # 2024-05-18T12:00:00Z in ms
+
+
+def test_parse_exif_datetime_with_negative_offset():
+    ms = c._parse_exif_datetime("2024:05:18 08:00:00", "-04:00")
+    # 08:00 UTC-4 == 12:00 UTC, same instant as the test above.
+    assert ms == 1716033600000
+
+
+def test_parse_exif_datetime_without_offset_uses_local_time():
+    # We can't pin the timezone in pure stdlib without zoneinfo + freezegun;
+    # just assert we got *some* sensible ms and that it differs predictably
+    # from the offset-aware case if the host isn't UTC.
+    raw = "2024:05:18 12:00:00"
+    naive_local = c._parse_exif_datetime(raw, None)
+    assert isinstance(naive_local, int)
+    assert naive_local > 0
+
+
+def test_parse_exif_datetime_rejects_garbage():
+    assert c._parse_exif_datetime("not a date", None) is None
+    assert c._parse_exif_datetime("0000:00:00 00:00:00", None) is None
+    assert c._parse_exif_datetime(None, None) is None
+    assert c._parse_exif_datetime("    ", None) is None
+
+
+# ── _read_local_exif ─────────────────────────────────────────────
+
+def _make_jpeg_with_exif(
+    tmp_path: Path,
+    *,
+    dt_original: str | None = None,
+    offset: str | None = None,
+    gps_lat: tuple | None = None,
+    gps_lat_ref: str | None = None,
+    gps_lon: tuple | None = None,
+    gps_lon_ref: str | None = None,
+    name: str = "photo.jpg",
+) -> Path:
+    img = Image.new("RGB", (32, 32), color=(0, 64, 128))
+    exif = img.getexif()
+    if dt_original:
+        exif[c._EXIF_TAG_DATETIME_ORIGINAL] = dt_original
+    if offset:
+        exif[c._EXIF_TAG_OFFSET_TIME_ORIGINAL] = offset
+    if gps_lat and gps_lat_ref and gps_lon and gps_lon_ref:
+        gps = exif.get_ifd(c._EXIF_TAG_GPS_IFD)
+        gps[c._EXIF_GPS_LAT] = gps_lat
+        gps[c._EXIF_GPS_LAT_REF] = gps_lat_ref
+        gps[c._EXIF_GPS_LON] = gps_lon
+        gps[c._EXIF_GPS_LON_REF] = gps_lon_ref
+    target = tmp_path / name
+    img.save(target, format="JPEG", exif=exif.tobytes())
+    return target
+
+
+def test_read_local_exif_picks_up_date_and_gps(tmp_path: Path):
+    p = _make_jpeg_with_exif(
+        tmp_path,
+        dt_original="2024:05:18 12:00:00",
+        offset="+00:00",
+        gps_lat=(37, 25, 19.07),
+        gps_lat_ref="N",
+        gps_lon=(122, 5, 6.0),
+        gps_lon_ref="W",
+    )
+    info = c._read_local_exif(p)
+    assert info["captured_at"] == 1716033600000
+    assert info["latitude"] == pytest.approx(37.4220, abs=1e-3)
+    assert info["longitude"] == pytest.approx(-122.085, abs=1e-3)
+
+
+def test_read_local_exif_falls_back_to_mtime(tmp_path: Path):
+    # JPEG with no EXIF date at all: we want a captured_at from mtime
+    # so date-based sorting still works.
+    p = tmp_path / "screenshot.jpg"
+    Image.new("RGB", (10, 10)).save(p, format="JPEG")
+    info = c._read_local_exif(p)
+    assert "captured_at" in info
+    assert info["captured_at"] > 0
+    assert "latitude" not in info
+
+
+def test_read_local_exif_null_island_is_dropped(tmp_path: Path):
+    # (0, 0) is the most common bogus GPS stamp; treat as "no GPS".
+    p = _make_jpeg_with_exif(
+        tmp_path,
+        gps_lat=(0, 0, 0),
+        gps_lat_ref="N",
+        gps_lon=(0, 0, 0),
+        gps_lon_ref="E",
+    )
+    info = c._read_local_exif(p)
+    assert "latitude" not in info
+    assert "longitude" not in info
+
+
+def test_read_local_exif_handles_non_image(tmp_path: Path):
+    p = tmp_path / "garbage.jpg"
+    p.write_bytes(b"this is not a JPEG")
+    info = c._read_local_exif(p)
+    # mtime fallback should still populate captured_at.
+    assert "captured_at" in info
+    assert "latitude" not in info
+
+
+# ── _format_nominatim_location ─────────────────────────────────────────
+
+def test_format_location_prefers_city():
+    payload = {
+        "address": {
+            "city": "Lisbon",
+            "town": "Should not appear",
+            "country": "Portugal",
+        }
+    }
+    assert c._format_nominatim_location(payload) == "Lisbon, Portugal"
+
+
+def test_format_location_falls_back_through_town_to_municipality():
+    payload = {
+        "address": {"municipality": "Cascais", "country": "Portugal"}
+    }
+    assert c._format_nominatim_location(payload) == "Cascais, Portugal"
+
+
+def test_format_location_uses_display_name_as_last_resort():
+    payload = {
+        "address": {},
+        "display_name": "Mid Atlantic Ridge, Atlantic Ocean, Nowhere",
+    }
+    assert c._format_nominatim_location(payload) == "Mid Atlantic Ridge, Atlantic Ocean"
+
+
+def test_format_location_returns_none_for_empty_payload():
+    assert c._format_nominatim_location({}) is None
+    assert c._format_nominatim_location(None) is None  # type: ignore[arg-type]
+
+
+# ── _nominatim_lookup ─────────────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status: int, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self, content_type=None):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict, dict]] = []
+
+    async def get(self, url, params=None, headers=None):
+        self.calls.append((url, dict(params or {}), dict(headers or {})))
+        if not self._responses:
+            raise AssertionError("Unexpected extra call to fake session")
+        return self._responses.pop(0)
+
+
+def test_nominatim_lookup_success_returns_label():
+    session = _FakeSession(
+        _FakeResp(200, {"address": {"city": "Paris", "country": "France"}})
+    )
+    label = asyncio.run(
+        c._nominatim_lookup(session, 48.8566, 2.3522, "album_slideshow/test")
+    )
+    assert label == "Paris, France"
+    assert len(session.calls) == 1
+    url, params, headers = session.calls[0]
+    assert url == c._NOMINATIM_ENDPOINT
+    assert params["format"] == "jsonv2"
+    assert params["lat"] == "48.85660"
+    assert params["lon"] == "2.35220"
+    assert headers["User-Agent"] == "album_slideshow/test"
+
+
+def test_nominatim_lookup_429_returns_none():
+    session = _FakeSession(_FakeResp(429, None))
+    label = asyncio.run(
+        c._nominatim_lookup(session, 1.0, 2.0, "ua")
+    )
+    assert label is None
+
+
+def test_nominatim_lookup_5xx_returns_none():
+    session = _FakeSession(_FakeResp(503, None))
+    label = asyncio.run(
+        c._nominatim_lookup(session, 1.0, 2.0, "ua")
+    )
+    assert label is None
+
+
+def test_nominatim_lookup_bad_json_returns_none():
+    session = _FakeSession(_FakeResp(200, ValueError("bad json")))
+    label = asyncio.run(
+        c._nominatim_lookup(session, 1.0, 2.0, "ua")
+    )
+    assert label is None
+
+
+def test_nominatim_lookup_session_exception_returns_none():
+    class _RaisingSession:
+        async def get(self, *a, **kw):
+            raise RuntimeError("network down")
+
+    label = asyncio.run(
+        c._nominatim_lookup(_RaisingSession(), 1.0, 2.0, "ua")
+    )
+    assert label is None
+
+
+# ── _merge_prior_enrichment ─────────────────────────────────────────
+
+def _item(url: str, **kw) -> c.MediaItem:
+    return c.MediaItem(
+        url=url, width=None, height=None, mime_type=None, filename=None, **kw
+    )
+
+
+def test_merge_prior_enrichment_carries_metadata_by_url():
+    prior = [
+        _item(
+            "file:///a.jpg",
+            captured_at=111,
+            latitude=1.0,
+            longitude=2.0,
+            location="Somewhere",
+            exif_scanned=True,
+        )
+    ]
+    new = [_item("file:///a.jpg"), _item("file:///b.jpg")]
+    c._merge_prior_enrichment(new, prior)
+    assert new[0].captured_at == 111
+    assert new[0].latitude == 1.0
+    assert new[0].location == "Somewhere"
+    assert new[0].exif_scanned is True
+    # New file untouched.
+    assert new[1].captured_at is None
+    assert new[1].exif_scanned is False
+
+
+def test_merge_prior_enrichment_does_not_overwrite_fresh_values():
+    prior = [_item("file:///a.jpg", captured_at=111, location="Old")]
+    new = [_item("file:///a.jpg", captured_at=222, location="New")]
+    c._merge_prior_enrichment(new, prior)
+    # Fresh value wins; merge is purely a backfill.
+    assert new[0].captured_at == 222
+    assert new[0].location == "New"
+
+
+# ── items-cache round trip ──────────────────────────────────────────
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.saved = None
+
+    async def async_load(self):
+        return self.saved
+
+    async def async_save(self, payload):
+        self.saved = payload
+
+
+def _stub_coordinator():
+    """Build the smallest coordinator-like object that supports the cache
+    round-trip methods. We bypass ``AlbumCoordinator.__init__`` entirely so
+    we don't need a real ``hass``/``entry``/``store``.
+    """
+    coord = c.AlbumCoordinator.__new__(c.AlbumCoordinator)
+    coord._items_cache_store = _RecordingStore()
+    coord._items_cache_loaded = False
+    return coord
+
+
+def test_save_and_load_round_trips_gps_and_scanned_flag():
+    coord = _stub_coordinator()
+    items = [
+        _item(
+            "file:///vacation.jpg",
+            captured_at=1716033600000,
+            latitude=37.4220,
+            longitude=-122.0850,
+            location="Mountain View, USA",
+            exif_scanned=True,
+            byte_size=4567,
+        ),
+        _item("file:///unscanned.jpg"),
+    ]
+    asyncio.run(
+        coord._save_cached_items({"title": "Vacation", "items": items})
+    )
+    loaded = asyncio.run(coord._load_cached_items())
+    assert loaded is not None
+    assert loaded["title"] == "Vacation"
+    out = loaded["items"]
+    assert len(out) == 2
+    assert out[0].latitude == pytest.approx(37.4220)
+    assert out[0].longitude == pytest.approx(-122.0850)
+    assert out[0].location == "Mountain View, USA"
+    assert out[0].exif_scanned is True
+    assert out[0].byte_size == 4567
+    # Unscanned item keeps its defaults.
+    assert out[1].latitude is None
+    assert out[1].exif_scanned is False
+
+
+# ── geocode opt-out via entry.options ──────────────────────────────────
+
+def test_geocode_phase_respects_opt_out():
+    """When ``reverse_geocode`` is False in entry.options, the geocode
+    pass must be a no-op even if items have GPS coordinates."""
+    coord = c.AlbumCoordinator.__new__(c.AlbumCoordinator)
+    coord.entry = SimpleNamespace(options={CONF_REVERSE_GEOCODE: False})
+    coord._enrich_progress = {
+        "phase": "geocoding",
+        "exif_total": 0,
+        "exif_done": 0,
+        "geocode_total": 0,
+        "geocode_done": 0,
+    }
+    items = [_item("file:///x.jpg", latitude=1.0, longitude=2.0)]
+    data = {"items": items}
+
+    # Should return immediately without touching ``location``.
+    asyncio.run(
+        coord._geocode_items_background(data)
+    )
+    assert items[0].location is None
+
+
+# ── _read_manifest_version ──────────────────────────────────────────
+
+def test_read_manifest_version_returns_string_or_empty(tmp_path: Path):
+    (tmp_path / "manifest.json").write_text(json.dumps({"version": "9.9.9"}))
+    assert c._read_manifest_version(tmp_path) == "9.9.9"
+
+
+def test_read_manifest_version_missing_returns_empty(tmp_path: Path):
+    # No manifest at all -> empty string, never raises.
+    assert c._read_manifest_version(tmp_path) == ""


### PR DESCRIPTION
## Summary

Adds first-class EXIF metadata, GPS coordinates, and optional reverse geocoding for local-folder / NAS album sources. Closes #9, #10, #13. Supersedes #11 / #12.

Local-folder entries currently surface `captured_at` / location attributes as `None`, so the date-filter sensors (last 7 days, on-this-day, newest taken…) only work for Google Photos albums. This PR closes that gap end-to-end:

- **EXIF capture date** with `OffsetTimeOriginal` honoured when present, host-local fallback otherwise; falls back further to file mtime so screenshots / scans still get a plausible "taken on" timestamp and sort correctly.
- **GPS coordinates** parsed from the EXIF GPS IFD, sign-corrected from the N/S/E/W refs, with a "null island" `(0,0)` guard. Exposed as `latitude` / `longitude` camera attributes.
- **Reverse geocoding** via the public OpenStreetMap Nominatim service to produce a human-readable `location` attribute (e.g. `"Lisbon, Portugal"`). Coordinates are rounded to ~100m before lookup and cached on disk, so the same neighbourhood is only ever fetched once.
- **Per-album opt-out** via an `OptionsFlow` (Settings → Devices & Services → *album* → Configure → "Reverse-geocode EXIF GPS coordinates"). Coordinates always stay local; only the geocode call is gated.
- **Background enrichment** runs after every coordinator refresh as a cancellable `hass.async_create_background_task`. Progress is exposed as the new `Enrichment progress` diagnostic sensor (percent complete, with `phase`, `exif_done/total`, `geocode_done/total` as attributes). Already-scanned files are tracked with an `exif_scanned` flag that round-trips through the items cache, so an HA restart doesn't re-decode every JPEG on disk.

## Operational hardening (resolves #13)

- Nominatim policy: 1.1s throttle, 20s timeout, descriptive `User-Agent` including the integration version + repo URL, graceful HTTP 429 backoff.
- Geocode cache key normalisation: coordinates rounded to 3 dp, `-0.0` folded to `0.0` so the cache key is stable across sign-of-zero quirks.
- `_nominatim_lookup` **never raises** — a flaky network must not stop the slideshow.
- Items-cache schema versioned (v2) and merged with prior enrichment on every refresh so renaming/moving files doesn't lose backfilled metadata.
- Pillow declared explicitly in `manifest.json` `requirements` (it already ships with HA core, but the explicit dependency is correct).

## Tests

New `tests/test_local_enrichment.py` with 34 tests covering:
- `_gps_to_decimal` sign / range / bytes-ref / `IFDRational` / malformed input
- `_geocode_cache_key` rounding + `-0.0` normalisation
- `_parse_exif_datetime` offset-aware vs naive vs garbage
- `_read_local_exif` end-to-end against Pillow-generated JPEGs (with EXIF, without EXIF, null-island, non-image bytes)
- `_format_nominatim_location` field-priority + display_name fallback
- `_nominatim_lookup` happy path, 429, 5xx, malformed JSON, session exception
- `_merge_prior_enrichment` URL-keyed backfill (and fresh values winning)
- Items-cache round-trip including GPS / `location` / `exif_scanned`
- Geocode phase respects the `reverse_geocode` opt-out
- `_read_manifest_version` returns string or "" without raising

Full suite: **121/121 passing locally on Python 3.14.5**.

CI: new `.github/workflows/tests.yaml` runs the suite on Python 3.11 + 3.12 (the versions HA core supports).

## Versioning

`manifest.json` bumped to `0.8.0`.

## Why a fresh PR

PRs #11 / #12 from @gargross tackled the same root cause but with a different shape (e.g. wiring EXIF reads inside the synchronous refresh path, no background task, no per-album opt-out, no geocode cache versioning, no enrichment progress sensor, no `exif_scanned` skip flag, no tests). Rather than incremental fixes, this PR rebuilds the feature on the integration's existing background-task + Store-versioned patterns so the same code paths handle refresh cancellation, restart recovery, and rate-limit backoff. Thanks to @gargross for surfacing the issue and exploring the design space.

Closes #9
Closes #10
Closes #13