### PR TITLE
Add Nextcloud public album link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Album Slideshow creates a **camera entity** that automatically cycles through im
 - **PhotoPrism** (direct API): album, person, favorites, all, or a custom search  
 - **iCloud** Shared Albums (public link)  
 - **Synology Photos** (direct API): favorites, albums, people, places, tags or subjects  
-- **Nextcloud** (WebDAV folder): any folder in your files, with full metadata  
+- **Nextcloud**: an authenticated WebDAV folder (full metadata) or a public Nextcloud Photos album link (no login needed)  
 - **Local folders** and NAS mounted directories  
 - Home Assistant **Media Source** (local media, Jellyfin, ...)  
 
@@ -44,7 +44,7 @@ All behavior is exposed as Home Assistant entities. Adjust everything live witho
 - **PhotoPrism** (direct API): album, person, favorites, all, or a custom search, with full metadata
 - **iCloud** Shared Albums (public link), with capture date + captions
 - **Synology Photos** (direct API): favorites, albums, people, places, tags or subjects, with full metadata
-- **Nextcloud** (WebDAV folder): any folder in your files (app-password auth, recursive), with full metadata
+- **Nextcloud**: an authenticated WebDAV folder (app-password auth, recursive, full metadata), or a public Nextcloud Photos album link (no login, full metadata)
 - **Local folder** paths and NAS mounted directories
 - Home Assistant **Media Source** (local media, Jellyfin, ...)
 - Optional recursive scanning
@@ -157,7 +157,8 @@ Pick the provider that matches where your photos live:
 | **PhotoPrism** | A PhotoPrism server (album, person, favorites, all, search) | ✅ | ✅ | ✅ |
 | **iCloud** | An iCloud Shared Album public link | ✅ | ❌ | ✅ |
 | **Synology** | A Synology Photos library (favorites, albums, people, places, tags, subjects) | ✅ | ✅ | ✅ |
-| **Nextcloud** | Any folder in your Nextcloud files (WebDAV, app password) | ✅ | ✅ | ✅ |
+| **Nextcloud (folder)** | Any folder in your Nextcloud files (WebDAV, app password) | ✅ | ✅ | ✅ |
+| **Nextcloud (public link)** | A public Nextcloud Photos album share link (no login) | ✅ | ✅ | ✅ |
 | **Local Folder** | Files on the HA host / NAS | ✅ | ✅ | ✅ |
 | **Media Source** | Any HA media source with no API (local media, Jellyfin, ...) | ❌ | ❌ | ❌ |
 
@@ -385,40 +386,60 @@ Synology serves pre-generated thumbnails:
 
 ### Nextcloud
 
-The **Nextcloud** provider slideshows **any folder in your Nextcloud files**
-over WebDAV, with **full photo metadata** (capture date, GPS location and
-captions). It works on any Nextcloud server - no Photos or Memories app is
-required.
+The **Nextcloud** provider has two connection modes, both with **full photo
+metadata** (capture date, GPS location and captions): an authenticated
+**WebDAV folder**, or a public **Nextcloud Photos album link** that needs no
+login. Add the integration, choose **Nextcloud**, then pick a connection type.
+
+#### Authenticated WebDAV folder
+
+Slideshows **any folder in your Nextcloud files** over WebDAV. Works on any
+Nextcloud server - no Photos or Memories app is required.
 
 1. In Nextcloud, create an **app password**: **Settings -> Security ->
    Devices & sessions -> Create new app password**. Copy the generated
    password (it is shown only once).
-2. Add the integration and choose **Nextcloud (WebDAV folder, full metadata)**.
+2. Choose **Authenticated WebDAV folder**.
 3. Enter your server URL (e.g. `https://cloud.example.com`), your username, and
    the app password.
 4. Point it at a **folder path** (e.g. `Photos/Family`), or leave it blank for
    your whole files root. Tick **Include subfolders** to recurse.
 5. Name it and pick an image quality.
 
+#### Public album link
+
+Slideshows a **public Nextcloud Photos album share**, with no Nextcloud
+login stored or required.
+
+1. In the Nextcloud **Photos** app, open the album you want to share and
+   create a **public link share** (or use an existing one).
+2. Choose **Public album link**.
+3. Paste the share link (e.g.
+   `https://cloud.example.com/apps/photos/public/AbC123`).
+4. Name it and pick an image quality.
+
 #### Image quality
 
-- **Preview** (default) - a resized thumbnail from Nextcloud's `core/preview`
-  endpoint; smoothest slideshow.
-- **Original** - the untouched original file straight off WebDAV (largest,
-  slowest).
+- **Preview** (default) - a resized thumbnail; smoothest slideshow.
+- **Original** - the untouched original file (largest, slowest).
 
 #### Notes
 
-- **Date, location and captions all work.** Nextcloud has no metadata-only API
-  for a folder, so the integration reads EXIF the same way the **Local Folder**
-  provider does: it downloads each original photo once in the background and
-  reads its EXIF/IPTC/XMP. Progress is tracked by the same **Enrichment
-  progress** diagnostic sensor, and the same reverse-geocoding opt-out applies
-  in the integration's **Configure** dialog.
-- The app password is stored so the integration can re-list the folder on each
-  refresh. It is sent to Nextcloud server-side only (HTTP Basic auth) and never
-  appears in the camera's image URL or the browser.
-- New photos dropped into the folder show up on the next refresh.
+- **Date, location and captions all work in both modes.** Nextcloud has no
+  metadata-only API, so the integration reads EXIF the same way the **Local
+  Folder** provider does: it downloads each original photo once in the
+  background and reads its EXIF/IPTC/XMP. Progress is tracked by the same
+  **Enrichment progress** diagnostic sensor, and the same reverse-geocoding
+  opt-out applies in the integration's **Configure** dialog.
+- **Folder mode:** the app password is stored so the integration can re-list
+  the folder on each refresh. It is sent to Nextcloud server-side only (HTTP
+  Basic auth) and never appears in the camera's image URL or the browser.
+- **Public link mode:** no credentials are stored - the share token embedded
+  in the link is the only thing the server checks. Anyone with the link (or
+  the camera's image URL) can view the photos, same as opening the share
+  page directly.
+- New photos dropped into the folder or added to the shared album show up on
+  the next refresh.
 - Videos and non-image files are skipped.
 
 ---

--- a/custom_components/album_slideshow/config_flow.py
+++ b/custom_components/album_slideshow/config_flow.py
@@ -77,6 +77,11 @@ from .const import (
     CONF_NEXTCLOUD_FOLDER,
     CONF_NEXTCLOUD_RECURSIVE,
     CONF_NEXTCLOUD_IMAGE_SIZE,
+    CONF_NEXTCLOUD_SHARE_TOKEN,
+    CONF_NEXTCLOUD_AUTH_MODE,
+    NEXTCLOUD_AUTH_MODE_FOLDER,
+    NEXTCLOUD_AUTH_MODE_PUBLIC,
+    DEFAULT_NEXTCLOUD_AUTH_MODE,
     DEFAULT_NEXTCLOUD_IMAGE_SIZE,
     NEXTCLOUD_IMAGE_PREVIEW,
     NEXTCLOUD_IMAGE_ORIGINAL,
@@ -203,7 +208,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     PROVIDER_PHOTOPRISM: "PhotoPrism (direct API, full metadata)",
                     PROVIDER_ICLOUD: "iCloud Shared Album",
                     PROVIDER_SYNOLOGY: "Synology Photos (direct API, full metadata)",
-                    PROVIDER_NEXTCLOUD: "Nextcloud (WebDAV folder, full metadata)",
+                    PROVIDER_NEXTCLOUD: "Nextcloud (WebDAV folder or public album link)",
                     PROVIDER_MEDIA_SOURCE: "Media Source (any source, no metadata)",
                 })
             }
@@ -937,6 +942,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_nextcloud(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
+        """Pick between an authenticated WebDAV folder and a public album link."""
+        if user_input is not None:
+            if user_input[CONF_NEXTCLOUD_AUTH_MODE] == NEXTCLOUD_AUTH_MODE_PUBLIC:
+                return await self.async_step_nextcloud_public()
+            return await self.async_step_nextcloud_folder()
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_NEXTCLOUD_AUTH_MODE, default=DEFAULT_NEXTCLOUD_AUTH_MODE
+                ): vol.In(
+                    {
+                        NEXTCLOUD_AUTH_MODE_FOLDER: "Authenticated WebDAV folder",
+                        NEXTCLOUD_AUTH_MODE_PUBLIC: "Public album link",
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(step_id="nextcloud", data_schema=schema)
+
+    async def async_step_nextcloud_folder(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Collect and validate a Nextcloud WebDAV folder + app password."""
         errors: dict[str, str] = {}
 
@@ -970,6 +998,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     title=name,
                     data={
                         CONF_PROVIDER: PROVIDER_NEXTCLOUD,
+                        CONF_NEXTCLOUD_AUTH_MODE: NEXTCLOUD_AUTH_MODE_FOLDER,
                         CONF_NEXTCLOUD_URL: client.base_url,
                         CONF_NEXTCLOUD_USERNAME: username,
                         CONF_NEXTCLOUD_PASSWORD: password,
@@ -1003,7 +1032,67 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(
-            step_id="nextcloud", data_schema=schema, errors=errors
+            step_id="nextcloud_folder", data_schema=schema, errors=errors
+        )
+
+    async def async_step_nextcloud_public(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Collect and validate a Nextcloud Photos public album link."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            name = user_input[CONF_ALBUM_NAME].strip()
+            raw_url = user_input[CONF_NEXTCLOUD_URL].strip()
+            size = user_input.get(
+                CONF_NEXTCLOUD_IMAGE_SIZE, DEFAULT_NEXTCLOUD_IMAGE_SIZE
+            )
+
+            from . import nextcloud as nc_api
+
+            parsed = nc_api.parse_share_link(raw_url)
+            if parsed is None:
+                errors[CONF_NEXTCLOUD_URL] = "invalid_nextcloud_url"
+            else:
+                base_url, token = parsed
+                client = nc_api.NextcloudPublicClient(self.hass, base_url, token)
+                try:
+                    await client.async_validate()
+                except Exception:  # noqa: BLE001 - any failure means bad/expired link
+                    errors["base"] = "nextcloud_public_cannot_connect"
+                else:
+                    await self.async_set_unique_id(
+                        f"{DOMAIN}:{PROVIDER_NEXTCLOUD}:{base_url}:{token}:{name}"
+                    )
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title=name,
+                        data={
+                            CONF_PROVIDER: PROVIDER_NEXTCLOUD,
+                            CONF_NEXTCLOUD_AUTH_MODE: NEXTCLOUD_AUTH_MODE_PUBLIC,
+                            CONF_NEXTCLOUD_URL: base_url,
+                            CONF_NEXTCLOUD_SHARE_TOKEN: token,
+                            CONF_NEXTCLOUD_IMAGE_SIZE: size,
+                            CONF_ALBUM_NAME: name,
+                        },
+                    )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_ALBUM_NAME): str,
+                vol.Required(CONF_NEXTCLOUD_URL): str,
+                vol.Optional(
+                    CONF_NEXTCLOUD_IMAGE_SIZE, default=DEFAULT_NEXTCLOUD_IMAGE_SIZE
+                ): vol.In(
+                    {
+                        NEXTCLOUD_IMAGE_PREVIEW: "Preview (smoothest slideshow)",
+                        NEXTCLOUD_IMAGE_ORIGINAL: "Original (full quality, slower)",
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="nextcloud_public", data_schema=schema, errors=errors
         )
 
 

--- a/custom_components/album_slideshow/const.py
+++ b/custom_components/album_slideshow/const.py
@@ -60,17 +60,29 @@ PROVIDER_ICLOUD = "icloud"
 PROVIDER_SYNOLOGY = "synology"
 PROVIDER_NEXTCLOUD = "nextcloud"
 
-# Nextcloud (authenticated WebDAV folder) provider. Points at any folder in a
-# user's files and lists it over WebDAV. Auth is HTTP Basic with a username +
-# app password (Settings > Security > Devices & sessions); the app password is
-# stored so the coordinator can re-list on each refresh and is sent server-side
-# only, never reaching the browser.
+# Nextcloud provider - two auth modes against the same PROVIDER_NEXTCLOUD id:
+#
+# - "folder": authenticated WebDAV folder. Points at any folder in a user's
+#   files and lists it over WebDAV. Auth is HTTP Basic with a username + app
+#   password (Settings > Security > Devices & sessions); the app password is
+#   stored so the coordinator can re-list on each refresh and is sent
+#   server-side only, never reaching the browser.
+# - "public_link": a public Nextcloud Photos album share link. No credentials
+#   involved - the share token embedded in the URL path is the only thing the
+#   server checks against the unauthenticated ``photospublic`` WebDAV
+#   collection.
+CONF_NEXTCLOUD_AUTH_MODE = "nextcloud_auth_mode"
+NEXTCLOUD_AUTH_MODE_FOLDER = "folder"
+NEXTCLOUD_AUTH_MODE_PUBLIC = "public_link"
+DEFAULT_NEXTCLOUD_AUTH_MODE = NEXTCLOUD_AUTH_MODE_FOLDER
+
 CONF_NEXTCLOUD_URL = "nextcloud_url"
 CONF_NEXTCLOUD_USERNAME = "nextcloud_username"
 CONF_NEXTCLOUD_PASSWORD = "nextcloud_password"
 CONF_NEXTCLOUD_FOLDER = "nextcloud_folder"
 CONF_NEXTCLOUD_RECURSIVE = "nextcloud_recursive"
 CONF_NEXTCLOUD_IMAGE_SIZE = "nextcloud_image_size"
+CONF_NEXTCLOUD_SHARE_TOKEN = "nextcloud_share_token"
 
 # ``preview`` uses the core/preview thumbnail endpoint (smoother, smaller);
 # ``original`` fetches the real file straight off the WebDAV collection.

--- a/custom_components/album_slideshow/coordinator.py
+++ b/custom_components/album_slideshow/coordinator.py
@@ -65,6 +65,10 @@ from .const import (
     CONF_NEXTCLOUD_FOLDER,
     CONF_NEXTCLOUD_RECURSIVE,
     CONF_NEXTCLOUD_IMAGE_SIZE,
+    CONF_NEXTCLOUD_SHARE_TOKEN,
+    CONF_NEXTCLOUD_AUTH_MODE,
+    NEXTCLOUD_AUTH_MODE_PUBLIC,
+    DEFAULT_NEXTCLOUD_AUTH_MODE,
     DEFAULT_NEXTCLOUD_IMAGE_SIZE,
     NEXTCLOUD_IMAGE_ORIGINAL,
     NEXTCLOUD_PREVIEW_PX,
@@ -1736,6 +1740,15 @@ class AlbumCoordinator(DataUpdateCoordinator):
         }
 
     async def _update_nextcloud(self) -> dict[str, Any]:
+        """List photos from Nextcloud, dispatching on the configured auth mode."""
+        mode = self.entry.data.get(
+            CONF_NEXTCLOUD_AUTH_MODE, DEFAULT_NEXTCLOUD_AUTH_MODE
+        )
+        if mode == NEXTCLOUD_AUTH_MODE_PUBLIC:
+            return await self._update_nextcloud_public()
+        return await self._update_nextcloud_folder()
+
+    async def _update_nextcloud_folder(self) -> dict[str, Any]:
         """List photos from an authenticated Nextcloud WebDAV folder.
 
         The PROPFIND listing carries filename/size/content-type/mtime but no
@@ -1799,39 +1812,83 @@ class AlbumCoordinator(DataUpdateCoordinator):
             "items": items,
         }
 
+    async def _update_nextcloud_public(self) -> dict[str, Any]:
+        """List photos from a Nextcloud Photos public collaborative album.
+
+        The PROPFIND listing carries filename/size/content-type/mtime but no
+        EXIF, so capture date, GPS and description are filled in afterwards
+        by the background enrichment worker (one original-file download per
+        photo - Nextcloud has no metadata-only endpoint the way Immich does).
+        No credentials are involved - the share token is embedded in the URL.
+        """
+        from . import nextcloud as nc_api
+
+        url = self.entry.data.get(CONF_NEXTCLOUD_URL)
+        token = self.entry.data.get(CONF_NEXTCLOUD_SHARE_TOKEN)
+        size = self.entry.data.get(
+            CONF_NEXTCLOUD_IMAGE_SIZE, DEFAULT_NEXTCLOUD_IMAGE_SIZE
+        )
+        if not url or not token:
+            raise UpdateFailed("Nextcloud provider is missing the URL or share token")
+
+        client = nc_api.NextcloudPublicClient(self.hass, url, token)
+        try:
+            photos = await client.async_list_photos()
+        except Exception as err:
+            raise UpdateFailed(f"Error listing Nextcloud album: {err}") from err
+
+        if not photos:
+            raise UpdateFailed("No images found in the Nextcloud album")
+
+        items: list[MediaItem] = []
+        for p in photos:
+            href = p.get("href")
+            if not href:
+                continue
+            if size != NEXTCLOUD_IMAGE_ORIGINAL and p.get("file_id"):
+                display_url = nc_api.build_preview_url_public(
+                    client.base_url, token, p["file_id"], NEXTCLOUD_PREVIEW_PX
+                )
+            else:
+                display_url = href
+            items.append(
+                MediaItem(
+                    url=display_url,
+                    width=None,
+                    height=None,
+                    mime_type=p.get("content_type"),
+                    filename=p.get("filename"),
+                    uploaded_at=p.get("mtime_ms"),
+                    byte_size=p.get("size"),
+                    source_id=p.get("file_id") or href,
+                )
+            )
+
+        return {
+            "title": self.entry.title,
+            "items": items,
+        }
+
     async def _enrich_nextcloud_item(self, item: MediaItem) -> None:
         """Download one Nextcloud photo's original bytes and read its EXIF.
 
-        Nextcloud's WebDAV folder has no metadata-only endpoint (unlike
+        Nextcloud has no metadata-only endpoint for either auth mode (unlike
         Immich's per-asset detail call), so enrichment costs one full-file
         download per photo regardless of the display quality configured.
+        Dispatches on the configured auth mode to build the right download
+        URL/headers; the download-and-parse tail is identical either way.
         """
-        from . import nextcloud as nc_api
-        from urllib.parse import quote
-
-        url = self.entry.data.get(CONF_NEXTCLOUD_URL)
-        username = self.entry.data.get(CONF_NEXTCLOUD_USERNAME)
-        password = self.entry.data.get(CONF_NEXTCLOUD_PASSWORD)
-        folder = self.entry.data.get(CONF_NEXTCLOUD_FOLDER) or ""
-        if not username or not password or not url:
-            item.exif_scanned = True
-            return
-
-        # Reconstruct the original-file URL: for preview items the display url
-        # is the preview endpoint, so fall back to the folder href by filename.
-        original_url = None
-        if isinstance(item.url, str) and "/remote.php/dav/files/" in item.url:
-            original_url = item.url
-        elif item.filename:
-            client = nc_api.NextcloudClient(self.hass, url, username, password, folder)
-            original_url = client.dav_root + quote(item.filename)
+        mode = self.entry.data.get(
+            CONF_NEXTCLOUD_AUTH_MODE, DEFAULT_NEXTCLOUD_AUTH_MODE
+        )
+        if mode == NEXTCLOUD_AUTH_MODE_PUBLIC:
+            original_url, headers = self._nextcloud_public_original(item)
+        else:
+            original_url, headers = self._nextcloud_folder_original(item)
         if not original_url:
             item.exif_scanned = True
             return
 
-        headers = {
-            "Authorization": nc_api.basic_auth_header(username, password)
-        }
         session = async_get_clientsession(self.hass)
         try:
             async with async_timeout.timeout(30):
@@ -1871,6 +1928,54 @@ class AlbumCoordinator(DataUpdateCoordinator):
             item.latitude = info["latitude"]
             item.longitude = info["longitude"]
         item.exif_scanned = True
+
+    def _nextcloud_folder_original(
+        self, item: MediaItem
+    ) -> tuple[str | None, dict[str, str]]:
+        """Return ``(original_url, headers)`` for a folder-mode item, or (None, {})."""
+        from . import nextcloud as nc_api
+        from urllib.parse import quote
+
+        url = self.entry.data.get(CONF_NEXTCLOUD_URL)
+        username = self.entry.data.get(CONF_NEXTCLOUD_USERNAME)
+        password = self.entry.data.get(CONF_NEXTCLOUD_PASSWORD)
+        folder = self.entry.data.get(CONF_NEXTCLOUD_FOLDER) or ""
+        if not username or not password or not url:
+            return None, {}
+
+        # Reconstruct the original-file URL: for preview items the display url
+        # is the preview endpoint, so fall back to the folder href by filename.
+        original_url = None
+        if isinstance(item.url, str) and "/remote.php/dav/files/" in item.url:
+            original_url = item.url
+        elif item.filename:
+            client = nc_api.NextcloudClient(self.hass, url, username, password, folder)
+            original_url = client.dav_root + quote(item.filename)
+        if not original_url:
+            return None, {}
+        return original_url, {"Authorization": nc_api.basic_auth_header(username, password)}
+
+    def _nextcloud_public_original(
+        self, item: MediaItem
+    ) -> tuple[str | None, dict[str, str]]:
+        """Return ``(original_url, headers)`` for a public-link item, or (None, {})."""
+        from . import nextcloud as nc_api
+
+        url = self.entry.data.get(CONF_NEXTCLOUD_URL)
+        token = self.entry.data.get(CONF_NEXTCLOUD_SHARE_TOKEN)
+        if not url or not token:
+            return None, {}
+
+        # Reconstruct the original-file URL: for preview items the display url
+        # is the preview endpoint, so fall back to the album href by filename.
+        original_url = None
+        if isinstance(item.url, str) and "/remote.php/dav/photospublic/" in item.url:
+            original_url = item.url
+        elif item.filename:
+            original_url = nc_api.build_image_url_public(url, token, item.filename)
+        if not original_url:
+            return None, {}
+        return original_url, {}
 
     async def _enrich_immich_item(self, item: MediaItem) -> None:
         """Fetch one Immich asset's detail and fill location/description."""

--- a/custom_components/album_slideshow/nextcloud.py
+++ b/custom_components/album_slideshow/nextcloud.py
@@ -21,11 +21,18 @@ Nextcloud has no metadata-only endpoint for WebDAV files, so capture date, GPS
 and description are filled in by the coordinator's background enrichment worker
 (one original-file download per photo, then read the EXIF - same idea as the
 Local Folder provider, just over the network).
+
+This module also supports a second, unauthenticated mode: a public Nextcloud
+Photos album share link, served via the ``photospublic`` WebDAV collection and
+handled by ``NextcloudPublicClient``. That mode's detailed API shape is
+documented in the ``## Public album link mode`` comment banner further down
+this file rather than duplicated here.
 """
 from __future__ import annotations
 
 import base64
 import email.utils
+import re
 from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
@@ -207,6 +214,22 @@ def parse_propfind_response(xml_text: str, root_url: str) -> list[dict[str, Any]
     return out
 
 
+async def _async_propfind(
+    hass: Any, url: str, depth: str, extra_headers: dict[str, str] | None = None
+) -> str:
+    """Issue a WebDAV PROPFIND against ``url`` and return the raw XML body."""
+    session = async_get_clientsession(hass)
+    headers = {"Depth": depth, "Content-Type": "application/xml"}
+    if extra_headers:
+        headers.update(extra_headers)
+    async with async_timeout.timeout(_TIMEOUT):
+        async with session.request(
+            "PROPFIND", url, data=_PROPFIND_BODY, headers=headers
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.text()
+
+
 class NextcloudClient:
     """Thin async wrapper over an authenticated WebDAV folder."""
 
@@ -229,18 +252,12 @@ class NextcloudClient:
         return {"Authorization": basic_auth_header(self.username, self.password)}
 
     async def _propfind(self, depth: str) -> str:
-        session = async_get_clientsession(self.hass)
-        headers = {
-            "Depth": depth,
-            "Content-Type": "application/xml",
-            "Authorization": basic_auth_header(self.username, self.password),
-        }
-        async with async_timeout.timeout(_TIMEOUT):
-            async with session.request(
-                "PROPFIND", self.dav_root, data=_PROPFIND_BODY, headers=headers
-            ) as resp:
-                resp.raise_for_status()
-                return await resp.text()
+        return await _async_propfind(
+            self.hass,
+            self.dav_root,
+            depth,
+            {"Authorization": basic_auth_header(self.username, self.password)},
+        )
 
     async def async_validate(self) -> None:
         """Confirm the URL, credentials and folder work. Raises on failure."""
@@ -249,4 +266,96 @@ class NextcloudClient:
     async def async_list_photos(self, recursive: bool = False) -> list[dict[str, Any]]:
         """Return the folder's image files (optionally recursing into it)."""
         xml_text = await self._propfind(depth="infinity" if recursive else "1")
+        return parse_propfind_response(xml_text, self.dav_root)[:_MAX_ASSETS]
+
+
+# ── Public album link mode ──────────────────────────────────────────────────
+#
+# Talks to the same ``photospublic`` WebDAV collection the Nextcloud Photos
+# app registers for a public album share - no session, API key, or Basic-auth
+# is involved; the share token embedded in the URL path is the only
+# credential the server checks (verified against the ``nextcloud/photos``
+# server source: ``PublicAlbumAuthBackend`` unconditionally authenticates any
+# request against a valid token).
+#
+# API shape:
+# - ``PROPFIND /remote.php/dav/photospublic/{token}/`` (Depth: 0) -> confirms
+#   the token is valid; used to validate the config flow input.
+# - ``PROPFIND /remote.php/dav/photospublic/{token}/`` (Depth: 1) -> the
+#   album's files, parsed by the shared ``parse_propfind_response`` above.
+# - ``GET /remote.php/dav/photospublic/{token}/{filename}`` -> the real
+#   original file bytes, used both as the "original" quality display URL and
+#   for background EXIF enrichment.
+# - ``GET /index.php/apps/photos/api/v1/publicPreview/{fileId}?token=...`` ->
+#   a resized preview JPEG, used as the "preview" (default) display quality.
+
+_PUBLIC_SHARE_LINK_RE = re.compile(
+    r"^(?P<base>https?://[^\s]+?)/(?:index\.php/)?apps/photos/public/"
+    r"(?P<token>[A-Za-z0-9]+)/?(?:[?#].*)?$"
+)
+
+
+def parse_share_link(url: str) -> tuple[str, str] | None:
+    """Extract ``(base_url, token)`` from a pasted public album link.
+
+    Returns ``None`` if the link doesn't look like a Nextcloud Photos public
+    album share (``.../apps/photos/public/{token}``, with or without
+    ``index.php`` or a subdirectory install).
+    """
+    if not url:
+        return None
+    match = _PUBLIC_SHARE_LINK_RE.match(url.strip())
+    if not match:
+        return None
+    return normalize_base_url(match.group("base")), match.group("token")
+
+
+def dav_root_public(base_url: str, token: str) -> str:
+    """Return the ``photospublic`` WebDAV collection URL for a shared album."""
+    return f"{normalize_base_url(base_url)}/remote.php/dav/photospublic/{token}/"
+
+
+def build_image_url_public(base_url: str, token: str, filename: str) -> str:
+    """Build the "original" quality URL: a direct WebDAV GET of the real file."""
+    return dav_root_public(base_url, token) + quote(filename)
+
+
+def build_preview_url_public(
+    base_url: str, token: str, file_id: str, px: int = 1024
+) -> str:
+    """Build the "preview" quality URL via the Photos app's publicPreview API."""
+    base = normalize_base_url(base_url)
+    return (
+        f"{base}/index.php/apps/photos/api/v1/publicPreview/{file_id}"
+        f"?token={token}&x={px}&y={px}"
+    )
+
+
+class NextcloudPublicClient:
+    """Thin async wrapper over a public ``photospublic`` WebDAV share.
+
+    Unlike :class:`NextcloudClient`, no authentication is involved - the
+    share token embedded in the URL path is the only credential the server
+    checks.
+    """
+
+    def __init__(self, hass: Any, base_url: str, token: str) -> None:
+        self.hass = hass
+        self.base_url = normalize_base_url(base_url)
+        self.token = token
+
+    @property
+    def dav_root(self) -> str:
+        return dav_root_public(self.base_url, self.token)
+
+    async def _propfind(self, depth: str) -> str:
+        return await _async_propfind(self.hass, self.dav_root, depth)
+
+    async def async_validate(self) -> None:
+        """Confirm the token/URL work. Raises on any failure."""
+        await self._propfind(depth="0")
+
+    async def async_list_photos(self) -> list[dict[str, Any]]:
+        """Return the album's image files."""
+        xml_text = await self._propfind(depth="1")
         return parse_propfind_response(xml_text, self.dav_root)[:_MAX_ASSETS]

--- a/custom_components/album_slideshow/strings.json
+++ b/custom_components/album_slideshow/strings.json
@@ -111,6 +111,13 @@
         }
       },
       "nextcloud": {
+        "title": "Nextcloud",
+        "description": "Choose how to connect: an authenticated WebDAV folder in your Nextcloud files, or a public Nextcloud Photos album share link.",
+        "data": {
+          "nextcloud_auth_mode": "Connection type"
+        }
+      },
+      "nextcloud_folder": {
         "title": "Nextcloud folder",
         "description": "Connect to a folder in your Nextcloud files over WebDAV. Enter the server address (e.g. http://192.168.1.10, or your Nextcloud domain over HTTPS), your username, and an app password (create one under Settings > Security > Devices and sessions - not your main login password). Point it at a folder path (e.g. Photos/Family), or leave the folder blank for your whole files root. Turn on recursive to include subfolders.",
         "data": {
@@ -120,6 +127,15 @@
           "nextcloud_password": "App password",
           "nextcloud_folder": "Folder path (optional)",
           "nextcloud_recursive": "Include subfolders",
+          "nextcloud_image_size": "Image quality"
+        }
+      },
+      "nextcloud_public": {
+        "title": "Nextcloud public album link",
+        "description": "Paste a public Nextcloud Photos album share link (from the Photos app's Share menu). No login is needed - the link itself grants access.",
+        "data": {
+          "album_name": "Album name",
+          "nextcloud_url": "Album share link",
           "nextcloud_image_size": "Image quality"
         }
       }
@@ -142,7 +158,9 @@
       "synology_cannot_connect": "Could not connect to Synology. Check the URL, username and password.",
       "synology_otp_required": "This account needs a two-factor code. Enter a current 6-digit code to continue.",
       "synology_shared_unavailable": "Could not access the Shared Space. Enable Shared Space in Synology Photos and make sure this account has access to it, or choose Personal instead.",
-      "nextcloud_cannot_connect": "Could not connect to Nextcloud. Check the URL, username, app password and folder path."
+      "nextcloud_cannot_connect": "Could not connect to Nextcloud. Check the URL, username, app password and folder path.",
+      "invalid_nextcloud_url": "That does not look like a Nextcloud Photos public album link.",
+      "nextcloud_public_cannot_connect": "Could not connect to that Nextcloud album. Check the link is still valid."
     }
   },
   "options": {

--- a/custom_components/album_slideshow/translations/en.json
+++ b/custom_components/album_slideshow/translations/en.json
@@ -111,6 +111,13 @@
         }
       },
       "nextcloud": {
+        "title": "Nextcloud",
+        "description": "Choose how to connect: an authenticated WebDAV folder in your Nextcloud files, or a public Nextcloud Photos album share link.",
+        "data": {
+          "nextcloud_auth_mode": "Connection type"
+        }
+      },
+      "nextcloud_folder": {
         "title": "Nextcloud folder",
         "description": "Connect to a folder in your Nextcloud files over WebDAV. Enter the server address (e.g. http://192.168.1.10, or your Nextcloud domain over HTTPS), your username, and an app password (create one under Settings > Security > Devices and sessions - not your main login password). Point it at a folder path (e.g. Photos/Family), or leave the folder blank for your whole files root. Turn on recursive to include subfolders.",
         "data": {
@@ -120,6 +127,15 @@
           "nextcloud_password": "App password",
           "nextcloud_folder": "Folder path (optional)",
           "nextcloud_recursive": "Include subfolders",
+          "nextcloud_image_size": "Image quality"
+        }
+      },
+      "nextcloud_public": {
+        "title": "Nextcloud public album link",
+        "description": "Paste a public Nextcloud Photos album share link (from the Photos app's Share menu). No login is needed - the link itself grants access.",
+        "data": {
+          "album_name": "Album name",
+          "nextcloud_url": "Album share link",
           "nextcloud_image_size": "Image quality"
         }
       }
@@ -142,7 +158,9 @@
       "synology_cannot_connect": "Could not connect to Synology. Check the URL, username and password.",
       "synology_otp_required": "This account needs a two-factor code. Enter a current 6-digit code to continue.",
       "synology_shared_unavailable": "Could not access the Shared Space. Enable Shared Space in Synology Photos and make sure this account has access to it, or choose Personal instead.",
-      "nextcloud_cannot_connect": "Could not connect to Nextcloud. Check the URL, username, app password and folder path."
+      "nextcloud_cannot_connect": "Could not connect to Nextcloud. Check the URL, username, app password and folder path.",
+      "invalid_nextcloud_url": "That does not look like a Nextcloud Photos public album link.",
+      "nextcloud_public_cannot_connect": "Could not connect to that Nextcloud album. Check the link is still valid."
     }
   },
   "options": {

--- a/tests/test_nextcloud.py
+++ b/tests/test_nextcloud.py
@@ -162,3 +162,102 @@ def test_parse_propfind_empty_returns_empty():
         '<?xml version="1.0"?><d:multistatus xmlns:d="DAV:"></d:multistatus>'
     )
     assert nc.parse_propfind_response(empty, _ROOT) == []
+
+
+# ── parse_share_link (public album link) ───────────────────────────────────
+
+def test_parse_share_link_pretty_url():
+    out = nc.parse_share_link("https://cloud.example.com/apps/photos/public/AbC123")
+    assert out == ("https://cloud.example.com", "AbC123")
+
+
+def test_parse_share_link_trailing_slash():
+    out = nc.parse_share_link("https://cloud.example.com/apps/photos/public/AbC123/")
+    assert out == ("https://cloud.example.com", "AbC123")
+
+
+def test_parse_share_link_index_php_form():
+    out = nc.parse_share_link(
+        "https://cloud.example.com/index.php/apps/photos/public/AbC123"
+    )
+    assert out == ("https://cloud.example.com", "AbC123")
+
+
+def test_parse_share_link_subdirectory_install():
+    out = nc.parse_share_link(
+        "https://example.com/nextcloud/apps/photos/public/AbC123"
+    )
+    assert out == ("https://example.com/nextcloud", "AbC123")
+
+
+def test_parse_share_link_with_query_string():
+    out = nc.parse_share_link(
+        "https://cloud.example.com/apps/photos/public/AbC123?foo=bar"
+    )
+    assert out == ("https://cloud.example.com", "AbC123")
+
+
+def test_parse_share_link_rejects_non_matching_url():
+    assert nc.parse_share_link("https://cloud.example.com/s/AbC123") is None
+    assert nc.parse_share_link("not a url") is None
+    assert nc.parse_share_link("") is None
+    assert nc.parse_share_link(None) is None
+
+
+# ── dav_root_public / build_image_url_public / build_preview_url_public ────
+
+def test_dav_root_public():
+    assert nc.dav_root_public("https://cloud.example.com", "AbC123") == (
+        "https://cloud.example.com/remote.php/dav/photospublic/AbC123/"
+    )
+
+
+def test_build_image_url_public():
+    url = nc.build_image_url_public(
+        "https://cloud.example.com", "AbC123", "photo one.jpg"
+    )
+    assert url == (
+        "https://cloud.example.com/remote.php/dav/photospublic/AbC123/photo%20one.jpg"
+    )
+
+
+def test_build_preview_url_public_default_size():
+    url = nc.build_preview_url_public("https://cloud.example.com", "AbC123", "456")
+    assert url == (
+        "https://cloud.example.com/index.php/apps/photos/api/v1/publicPreview/456"
+        "?token=AbC123&x=1024&y=1024"
+    )
+
+
+def test_build_preview_url_public_custom_size():
+    url = nc.build_preview_url_public(
+        "https://cloud.example.com", "AbC123", "456", px=256
+    )
+    assert "x=256&y=256" in url
+
+
+# ── parse_propfind_response: real-server multi-propstat root regression ────
+# Shape verified against a real Nextcloud server (28.x-era): the root
+# collection's <d:response> carries *two* propstats - one 200 with just
+# resourcetype, and a second 404 Not Found for props a folder can't answer
+# (getcontenttype/getcontentlength/getlastmodified/oc:fileid). A parser that
+# naively grabs the first <d:prop> it finds per response (instead of picking
+# the 200 propstat) would silently work for this shape too, but one that
+# grabs the *last* prop block, or merges both, would not - this pins the real
+# multi-propstat structure so a regression stays caught. Exercises the shared
+# parse_propfind_response, so it protects both auth modes.
+
+_REAL_SHAPE_MULTISTATUS = """<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns"><d:response><d:href>/remote.php/dav/photospublic/AbC123/</d:href><d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat><d:propstat><d:prop><d:getcontenttype/><d:getcontentlength/><d:getlastmodified/><oc:fileid/></d:prop><d:status>HTTP/1.1 404 Not Found</d:status></d:propstat></d:response><d:response><d:href>/remote.php/dav/photospublic/AbC123/12345-20260518_190350.jpg</d:href><d:propstat><d:prop><d:getcontenttype>image/jpeg</d:getcontenttype><d:getcontentlength>4424803</d:getcontentlength><d:getlastmodified>Mon, 18 May 2026 17:03:51 GMT</d:getlastmodified><d:resourcetype/><oc:fileid>12345</oc:fileid></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response></d:multistatus>
+"""
+
+
+def test_parse_propfind_real_server_shape_multi_propstat_root():
+    root = "https://cloud.example.com/remote.php/dav/photospublic/AbC123/"
+    items = nc.parse_propfind_response(_REAL_SHAPE_MULTISTATUS, root)
+    assert len(items) == 1
+    photo = items[0]
+    assert photo["filename"] == "12345-20260518_190350.jpg"
+    assert photo["content_type"] == "image/jpeg"
+    assert photo["size"] == 4424803
+    assert photo["file_id"] == "12345"


### PR DESCRIPTION
## Summary

Adds a second connection mode to the existing Nextcloud provider: a **public Nextcloud Photos album share link** (the unauthenticated `photospublic` WebDAV collection, share token embedded in the URL — no login required), alongside the existing authenticated WebDAV folder mode.

- The Nextcloud config-flow step becomes a connection-type picker (mirrors the existing top-level provider picker's own pattern) that branches to the original folder-setup form or a new, shorter public-link form.
- `nextcloud.py` gains a `NextcloudPublicClient` and public-mode URL helpers, purely additive alongside the existing `NextcloudClient` — both share the existing WebDAV multistatus parser.
- The coordinator's update/enrichment methods dispatch on a new `nextcloud_auth_mode` config-entry field.
- Default auth mode is `folder`, so every existing installed entry (which predates this field) keeps working exactly as before with zero migration needed.